### PR TITLE
Fix for #7: Random is now thread safe

### DIFF
--- a/src/OpenCensus/Impl/Trace/Internal/RandomGenerator.cs
+++ b/src/OpenCensus/Impl/Trace/Internal/RandomGenerator.cs
@@ -6,7 +6,6 @@ namespace OpenCensus.Trace.Internal
     internal class RandomGenerator : IRandomGenerator
     {
         private static readonly Random _global = new Random();
-        private static readonly object _lockObj = new object();
 
         private readonly int _seed;
         private readonly bool _sameSeed;
@@ -29,14 +28,10 @@ namespace OpenCensus.Trace.Internal
         }
 
         public void NextBytes(byte[] bytes)
-        {
+        {            
             if (_local == null)
-            {
-                lock(_lockObj)
-                {
-                    if (_local == null)
-                        _local = new Random(_sameSeed ? _seed : _global.Next());
-                }
+            {                
+                _local = new Random(_sameSeed ? _seed : _global.Next());                
             }
             _local.NextBytes(bytes);
         }

--- a/src/OpenCensus/Impl/Trace/Internal/RandomGenerator.cs
+++ b/src/OpenCensus/Impl/Trace/Internal/RandomGenerator.cs
@@ -5,20 +5,34 @@ namespace OpenCensus.Trace.Internal
 {
     internal class RandomGenerator : IRandomGenerator
     {
-        private Random _random;
+        private static readonly Random _global = new Random();
+        private static readonly object _lockObj = new object();
+
+        private readonly int _seed;
+        [ThreadStatic] private static Random _local;
+
+
         internal RandomGenerator()
         {
-            _random = new Random();
+            _seed = _global.Next();
         }
 
         internal RandomGenerator(int seed)
         {
-            _random = new Random(seed);
+            _seed = seed;
         }
 
         public void NextBytes(byte[] bytes)
         {
-            _random.NextBytes(bytes);
+            if (_local == null)
+            {
+                lock(_lockObj)
+                {
+                    if (_local == null)
+                        _local = new Random(_seed);
+                }
+            }
+            _local.NextBytes(bytes);
         }
     }
 }

--- a/src/OpenCensus/Impl/Trace/Internal/RandomGenerator.cs
+++ b/src/OpenCensus/Impl/Trace/Internal/RandomGenerator.cs
@@ -9,16 +9,22 @@ namespace OpenCensus.Trace.Internal
         private static readonly object _lockObj = new object();
 
         private readonly int _seed;
+        private readonly bool _sameSeed;
         [ThreadStatic] private static Random _local;
-
 
         internal RandomGenerator()
         {
-            _seed = _global.Next();
+            _sameSeed = false;
         }
 
+        /// <summary>
+        /// This constructur uses the same seed for all the thread static random objects.
+        /// You might get the same values if a random is accessed from different threads.
+        /// Use only for unit tests...
+        /// </summary>
         internal RandomGenerator(int seed)
         {
+            _sameSeed = true;
             _seed = seed;
         }
 
@@ -29,7 +35,7 @@ namespace OpenCensus.Trace.Internal
                 lock(_lockObj)
                 {
                     if (_local == null)
-                        _local = new Random(_seed);
+                        _local = new Random(_sameSeed ? _seed : _global.Next());
                 }
             }
             _local.NextBytes(bytes);

--- a/test/OpenCensus.Tests/Impl/Trace/Sampler/SamplersTest.cs
+++ b/test/OpenCensus.Tests/Impl/Trace/Sampler/SamplersTest.cs
@@ -2,6 +2,7 @@
 using OpenCensus.Trace.Test;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using Xunit;
 
 namespace OpenCensus.Trace.Sampler.Test
@@ -240,7 +241,8 @@ namespace OpenCensus.Trace.Sampler.Test
         [Fact]
         public void ProbabilitySampler_ToString()
         {
-            Assert.Contains("0.5", Samplers.GetProbabilitySampler(0.5).ToString());
+            var result = Samplers.GetProbabilitySampler(0.5).ToString();
+            Assert.Contains($"0{CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator}5", result);
         }
 
         // Applies the given sampler to NUM_SAMPLE_TRIES random traceId/spanId pairs.


### PR DESCRIPTION
Updated the random class to use a new random object for each seperate thread.

Had problems running a single unit tests due to a localization issue. Made a fix on that one as well.