### PR TITLE
Demonstrate concurrency bug in CurrentStatsState.

### DIFF
--- a/src/OpenCensus/Impl/Stats/CurrentStatsState.cs
+++ b/src/OpenCensus/Impl/Stats/CurrentStatsState.cs
@@ -52,19 +52,22 @@ namespace OpenCensus.Stats
         // otherwise.
         internal bool Set(StatsCollectionState state)
         {
-            if (this.isRead)
+            lock (this.lck)
             {
-                throw new ArgumentException("State was already read, cannot set state.");
-            }
+                if (this.isRead)
+                {
+                    throw new ArgumentException("State was already read, cannot set state.");
+                }
 
-            if (state == this.currentState)
-            {
-                return false;
-            }
-            else
-            {
-                this.currentState = state;
-                return true;
+                if (state == this.currentState)
+                {
+                    return false;
+                }
+                else
+                {
+                    this.currentState = state;
+                    return true;
+                }
             }
         }
     }

--- a/test/OpenCensus.Tests/Impl/Stats/BucketBoundariesTest.cs
+++ b/test/OpenCensus.Tests/Impl/Stats/BucketBoundariesTest.cs
@@ -74,10 +74,16 @@ namespace OpenCensus.Stats.Test
             var b2 = BucketBoundaries.Create(new List<double>() { -1.0, 2.0 });
             var b3 = BucketBoundaries.Create(new List<double>() { -1.0 });
             Assert.Equal(b1, b2);
+            Assert.Equal(b2, b1);
             Assert.Equal(b3, b3);
             Assert.NotEqual(b1, b3);
             Assert.NotEqual(b2, b3);
 
+            Assert.True(b1 == b2);
+            Assert.True(b2 == b1);
+            Assert.True(b3 == b3);
+            Assert.False(b1 == b3);
+            Assert.False(b2 == b3);
         }
     }
 }

--- a/test/OpenCensus.Tests/Impl/Stats/BucketBoundariesTest.cs
+++ b/test/OpenCensus.Tests/Impl/Stats/BucketBoundariesTest.cs
@@ -74,16 +74,10 @@ namespace OpenCensus.Stats.Test
             var b2 = BucketBoundaries.Create(new List<double>() { -1.0, 2.0 });
             var b3 = BucketBoundaries.Create(new List<double>() { -1.0 });
             Assert.Equal(b1, b2);
-            Assert.Equal(b2, b1);
             Assert.Equal(b3, b3);
             Assert.NotEqual(b1, b3);
             Assert.NotEqual(b2, b3);
 
-            Assert.True(b1 == b2);
-            Assert.True(b2 == b1);
-            Assert.True(b3 == b3);
-            Assert.False(b1 == b3);
-            Assert.False(b2 == b3);
         }
     }
 }


### PR DESCRIPTION
In reality, we probably want a ReaderWriterLock for less contention, though