### PR TITLE
Updates to the build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: csharp
-mono: none
-dotnet: 2.1.500
-script:
-  - dotnet restore
-  - dotnet build 
-  - dotnet test

--- a/.vsts/ci-build.yml
+++ b/.vsts/ci-build.yml
@@ -1,7 +1,7 @@
 # CI build. No publioshing of artifacts
 
 variables:
-  DotNetVersion: "2.1.402"
+  DotNetVersion: "2.2.100"
 
 phases:
 
@@ -38,7 +38,7 @@ phases:
   - task: PublishTestResults@2
 
 - phase: Linux
-  queue: Hosted Linux Preview
+  queue: Hosted Ubuntu 1604
   steps:
   - task: DotNetCoreInstaller@0
     displayName: force use of desired dotnet version

--- a/.vsts/ci-build.yml
+++ b/.vsts/ci-build.yml
@@ -1,7 +1,7 @@
 # CI build. No publioshing of artifacts
 
 variables:
-  DotNetVersion: "2.2"
+  DotNetVersion: "2.2.101"
 
 phases:
 

--- a/.vsts/ci-build.yml
+++ b/.vsts/ci-build.yml
@@ -1,7 +1,7 @@
 # CI build. No publioshing of artifacts
 
 variables:
-  DotNetVersion: "2.2.100"
+  DotNetVersion: "2.2"
 
 phases:
 

--- a/.vsts/ci-build.yml
+++ b/.vsts/ci-build.yml
@@ -14,12 +14,7 @@ phases:
     inputs:
       version: $(DotNetVersion)
 
-  - task: DotNetCoreCLI@2
-    displayName: restore packages
-    inputs:
-      command: "restore"
-      projects: "*.sln"
-
+  # "restore" is run automatically by "build"
   - task: DotNetCoreCLI@2
     displayName: build solution (Release)
     inputs:
@@ -45,12 +40,7 @@ phases:
     inputs:
       version: $(DotNetVersion)
 
-  - task: DotNetCoreCLI@2
-    displayName: restore packages
-    inputs:
-      command: "restore"
-      projects: "*.sln"
-
+  # "restore" is run automatically by "build"
   - task: DotNetCoreCLI@2
     displayName: build
     inputs:

--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -18,9 +18,6 @@ steps:
     version: $(DotNetVersion)
 
 # "build" and "restore" are run by "pack".
-# See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack?tabs=netcore2x
-# arguments parameter doesn't seems to be working: https://github.com/Microsoft/azure-pipelines-tasks/issues/9107
-# One option to work around it is potentially switch to MSBuild task
 - task: DotNetCoreCLI@2
   displayName: pack solution with symbols (Release)
   inputs:

--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -1,7 +1,7 @@
 # CI build with the upload to MyGet
 
 variables:
-  DotNetVersion: "2.2.100"
+  DotNetVersion: "2.2.101"
 
 trigger:
   branches:

--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -18,6 +18,8 @@ steps:
 
 # "build" and "restore" are run by "pack".
 # See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack?tabs=netcore2x
+# arguments parameter doesn't seems to be working: https://github.com/Microsoft/azure-pipelines-tasks/issues/9107
+# One option to work around it is potentially switch to MSBuild task
 - task: DotNetCoreCLI@2
   displayName: pack solution with symbols (Release)
   inputs:

--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -16,19 +16,8 @@ steps:
   inputs:
     version: $(DotNetVersion)
 
-- task: DotNetCoreCLI@2
-  displayName: restore packages
-  inputs:
-    command: "restore"
-    projects: "*.sln"
-
-- task: DotNetCoreCLI@2
-  displayName: build solution (Release)
-  inputs:
-    command: "build"
-    projects: "*.sln"
-    arguments: "--configuration Release"
-
+# "build" and "restore" are run by "pack".
+# See https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-pack?tabs=netcore2x
 - task: DotNetCoreCLI@2
   displayName: pack solution with symbols (Release)
   inputs:
@@ -54,6 +43,7 @@ steps:
     nuGetFeedType: external
     publishFeedCredentials: 'myget-open-census'
 
+# this task is required as symbols packages needs to be published manually.
 - task: PublishBuildArtifacts@1
   inputs:
     PathtoPublish: "$(build.artifactstagingdirectory)"

--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -30,7 +30,7 @@ steps:
     arguments: "--configuration Release"
 
 - task: DotNetCoreCLI@2
-  displayName: pack solution (Release)
+  displayName: pack solution with symbols (Release)
   inputs:
     command: "pack"
     projects: "*.sln"
@@ -46,14 +46,6 @@ steps:
     arguments: "--configuration Release"
 
 - task: PublishTestResults@2
-
-- task: DotNetCoreCLI@1
-  displayName: publish
-  inputs:
-    command: "publish"
-    publishWebProjects: "True"
-    arguments: "--configuration Release --output $(build.artifactstagingdirectory)"
-    zipAfterPublish: "True"
 
 - task: NuGetCommand@2
   displayName: 'Publish nugets to MyGet'

--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -10,6 +10,7 @@ trigger:
     - develop
 
 queue: Hosted VS2017
+
 steps:
 - task: DotNetCoreInstaller@0
   displayName: force use of desired dotnet version
@@ -27,7 +28,7 @@ steps:
     projects: "*.sln"
     configuration: 'Release'
     packDirectory: '$(build.artifactStagingDirectory)'
-    arguments: "-p:SymbolPackageFormat=snupkg"
+    buildProperties: "SymbolPackageFormat=snupkg"
 
 - task: DotNetCoreCLI@2
   displayName: test

--- a/.vsts/ci-myget-update.yml
+++ b/.vsts/ci-myget-update.yml
@@ -1,7 +1,7 @@
 # CI build with the upload to MyGet
 
 variables:
-  DotNetVersion: "2.1.402"
+  DotNetVersion: "2.2.100"
 
 trigger:
   branches:
@@ -36,6 +36,7 @@ steps:
     projects: "*.sln"
     configuration: 'Release'
     packDirectory: '$(build.artifactStagingDirectory)'
+    arguments: "-p:SymbolPackageFormat=snupkg"
 
 - task: DotNetCoreCLI@2
   displayName: test


### PR DESCRIPTION
1. removing travis and keeping only Azure Pipelines. Travis's dotnet support is experimental while Azure pipelines has full support on both - Linux and Windows.
2. No need to restore and build when pack.
3. Update to `dotnet` version 2.2 to enable snupkg
4. Enabling of snupkg is blocked - added a comment with the reference to the issue. If issue will not be resolved I'll switch to simple run of a command line instead.