### PR TITLE
Updating the sample for zipkin exporter to follow quickstart at opencensus.io

### DIFF
--- a/src/OpenCensus.Collector.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenCensus.Collector.AspNetCore/Implementation/HttpInListener.cs
@@ -67,7 +67,7 @@ namespace OpenCensus.Collector.AspNetCore.Implementation
 
             if (span != null)
             {
-                // TODO: Note, route is missing at this stage. It will be available later
+                // Note, route is missing at this stage. It will be available later
 
                 span.PutServerSpanKindAttribute();
                 span.PutHttpHostAttribute(request.Host.Host, request.Host.Port ?? 80);

--- a/src/OpenCensus.Collector.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenCensus.Collector.AspNetCore/Implementation/HttpInListener.cs
@@ -67,7 +67,7 @@ namespace OpenCensus.Collector.AspNetCore.Implementation
 
             if (span != null)
             {
-                // Note, route is missing at this stage. It will be available later
+                // TODO: Note, route is missing at this stage. It will be available later
 
                 span.PutServerSpanKindAttribute();
                 span.PutHttpHostAttribute(request.Host.Host, request.Host.Port ?? 80);

--- a/src/Samples/Program.cs
+++ b/src/Samples/Program.cs
@@ -1,6 +1,7 @@
 ﻿namespace Samples
 {
     using CommandLine;
+    using System;
 
     [Verb("stackdriver", HelpText = "Specify the options required to test Stackdriver exporter", Hidden = false)]
     class StackdriverOptions
@@ -55,6 +56,8 @@
                     (HttpClientOptions options) => TestHttpClient.Run(),
                     (StackdriverOptions options) => TestStackdriver.Run(options.ProjectId),
                     errs => 1);
+
+            Console.ReadLine();
         }
     }
 }

--- a/src/Samples/Program.cs
+++ b/src/Samples/Program.cs
@@ -1,7 +1,6 @@
 ﻿namespace Samples
 {
     using CommandLine;
-    using System;
 
     [Verb("stackdriver", HelpText = "Specify the options required to test Stackdriver exporter", Hidden = false)]
     class StackdriverOptions
@@ -13,6 +12,8 @@
     [Verb("zipkin", HelpText = "Specify the options required to test Zipkin exporter")]
     class ZipkinOptions
     {
+        [Option('u', "uri", HelpText = "Please specify the uri of Zipkin backend", Required = true)]
+        public string Uri { get; set; }
     }
 
     [Verb("appInsights", HelpText = "Specify the options required to test ApplicationInsights")]
@@ -39,7 +40,7 @@
         /// Main method - invoke this using command line.
         /// For example:
         /// 
-        /// Samples.dll zipkin
+        /// Samples.dll zipkin http://localhost:9411/api/v2/spans
         /// Sample.dll appInsights
         /// Sample.dll prometheus
         /// </summary>
@@ -48,17 +49,12 @@
         {
             Parser.Default.ParseArguments<ZipkinOptions, ApplicationInsightsOptions, PrometheusOptions, HttpClientOptions, StackdriverOptions>(args)
                 .MapResult(
-                    (ZipkinOptions options) => TestZipkin.Run(),
+                    (ZipkinOptions options) => TestZipkin.Run(options.Uri),
                     (ApplicationInsightsOptions options) => TestApplicationInsights.Run(),
                     (PrometheusOptions options) => TestPrometheus.Run(),
                     (HttpClientOptions options) => TestHttpClient.Run(),
                     (StackdriverOptions options) => TestStackdriver.Run(options.ProjectId),
                     errs => 1);
-                    
-            // TestZipkin.Run();
-            // TestApplicationInsights.Run();
-            // TestPrometheus.Run();
-            // TestHttpClient.Run();
         }
     }
 }

--- a/src/Samples/TestZipkin.cs
+++ b/src/Samples/TestZipkin.cs
@@ -10,14 +10,14 @@
     {
         private static ITracer tracer = Tracing.Tracer;
 
-        internal static object Run()
+        internal static object Run(string zipkinUri)
         {
             Console.WriteLine("Hello World!");
 
             var exporter = new ZipkinTraceExporter(
                 new ZipkinTraceExporterOptions()
                 {
-                    Endpoint = new Uri("https://zipkin.azurewebsites.net/api/v2/spans"),
+                    Endpoint = new Uri(zipkinUri),
                     ServiceName = typeof(Program).Assembly.GetName().Name,
                 },
                 Tracing.ExportComponent);
@@ -27,6 +27,8 @@
 
             Thread.Sleep(TimeSpan.FromSeconds(1));
             var span2 = tracer.CurrentSpan;
+            //span2.PutAttribute("computername", AttributeValue.StringAttributeValue(Environment.MachineName));
+            Tracing.Tracer.CurrentSpan.PutAttribute("computer", AttributeValue.StringAttributeValue(Environment.MachineName));
             span2.End();
 
             Console.ReadLine();

--- a/src/Samples/TestZipkin.cs
+++ b/src/Samples/TestZipkin.cs
@@ -1,37 +1,84 @@
 ﻿namespace Samples
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using OpenCensus.Exporter.Zipkin;
     using OpenCensus.Trace;
+    using OpenCensus.Trace.Config;
     using OpenCensus.Trace.Sampler;
 
     internal class TestZipkin
     {
-        private static ITracer tracer = Tracing.Tracer;
-
         internal static object Run(string zipkinUri)
         {
-            Console.WriteLine("Hello World!");
-
+            // 1. Configure exporter to export traces to Zipkin
             var exporter = new ZipkinTraceExporter(
                 new ZipkinTraceExporterOptions()
                 {
                     Endpoint = new Uri(zipkinUri),
-                    ServiceName = typeof(Program).Assembly.GetName().Name,
+                    ServiceName = "tracing-to-zipkin-service",
                 },
                 Tracing.ExportComponent);
             exporter.Start();
 
-            var span = tracer.SpanBuilder("incoming request").SetSampler(Samplers.AlwaysSample).StartScopedSpan();
+            // 2. Configure 100% sample rate for the purposes of the demo
+            ITraceConfig traceConfig = Tracing.TraceConfig;
+            ITraceParams currentConfig = traceConfig.ActiveTraceParams;
+            var newConfig = currentConfig.ToBuilder()
+                .SetSampler(Samplers.AlwaysSample)
+                .Build();
+            traceConfig.UpdateActiveTraceParams(newConfig);
 
-            Thread.Sleep(TimeSpan.FromSeconds(1));
-            var span2 = tracer.CurrentSpan;
-            span2.End();
+            // 3. Tracer is global singleton. You can register it via dependency injection if it exists
+            // but if not - you can use it as follows:
+            var tracer = Tracing.Tracer;
 
-            Console.ReadLine();
+            // 4. Create a scoped span. It will end automatically when using statement ends
+            using (var scope = tracer.SpanBuilder("Main").StartScopedSpan())
+            {
+                Console.WriteLine("About to do a busy work");
+                for (int i = 0; i < 10; i++)
+                {
+                    DoWork(i);
+                }
+            }
+
+            // 5. Gracefully shutdown the exporter so it'll flush queued traces to Zipkin.
+            Tracing.ExportComponent.SpanExporter.Dispose();
 
             return null;
+        }
+
+        private static void DoWork(int i)
+        {
+            // 6. Get the global singleton Tracer object
+            ITracer tracer = Tracing.Tracer;
+
+            // 7. Start another span. If another span was already started, it'll use that span as the parent span.
+            // In this example, the main method already started a span, so that'll be the parent span, and this will be
+            // a child span.
+            using (OpenCensus.Common.IScope scope = tracer.SpanBuilder("DoWork").StartScopedSpan())
+            {
+                // Simulate some work.
+                ISpan span = tracer.CurrentSpan;
+
+                try
+                {
+                    Console.WriteLine("Doing busy work");
+                    Thread.Sleep(1000);
+                }
+                catch (ArgumentOutOfRangeException e)
+                {
+                    // 6. Set status upon error
+                    span.Status = Status.Internal.WithDescription(e.ToString());
+                }
+
+                // 7. Annotate our span to capture metadata about our operation
+                var attributes = new Dictionary<string, IAttributeValue>();
+                attributes.Add("use", AttributeValue.StringAttributeValue("demo"));
+                span.AddAnnotation("Invoking DoWork", attributes);
+            }
         }
     }
 }

--- a/src/Samples/TestZipkin.cs
+++ b/src/Samples/TestZipkin.cs
@@ -27,8 +27,6 @@
 
             Thread.Sleep(TimeSpan.FromSeconds(1));
             var span2 = tracer.CurrentSpan;
-            //span2.PutAttribute("computername", AttributeValue.StringAttributeValue(Environment.MachineName));
-            Tracing.Tracer.CurrentSpan.PutAttribute("computer", AttributeValue.StringAttributeValue(Environment.MachineName));
             span2.End();
 
             Console.ReadLine();


### PR DESCRIPTION
Other quickstarts: https://github.com/census-instrumentation/opencensus-website/tree/master/content/quickstart

.NET proposed quickstart for Opencensus.io that is based on updated sample in this PR:
https://github.com/census-instrumentation/opencensus-website/pull/523

Currently opencensus.io website can't embed code from another repository, so the PR above contains readme.MD with code explanations that is based on the code in this PR. There is ongoing work on figuring out how to embed code samples, at which point changing the sample in this repo will be automatically reflected in opencensus.io website.