### PR TITLE
Adds MVC middleware for Prometheus Exporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the release.
 - Plug in to collect Redis calls made using StackExchange.Redis package.
 - Object of type `ISpanData` can be created using only Abstractions package.
 - Number of minor APIs adjustments.
+- Added MVC Middleware for Prometheus Exporter.
 
 ## 0.1.0-alpha-33381
 

--- a/src/OpenCensus.Exporter.Prometheus/Implementation/MetricsHttpServer.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Implementation/MetricsHttpServer.cs
@@ -55,7 +55,7 @@ namespace OpenCensus.Exporter.Prometheus.Implementation
 
                     using (var output = ctx.Response.OutputStream)
                     {
-                        MetricsWriter.WriteMetrics(output, this.viewManager);
+                        MetricsWriter.Write(output, this.viewManager);
                     }
                 }
             }

--- a/src/OpenCensus.Exporter.Prometheus/Implementation/MetricsWriter.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Implementation/MetricsWriter.cs
@@ -1,0 +1,77 @@
+// <copyright file="MetricsWriter.cs" company="OpenCensus Authors">
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenCensus.Exporter.Prometheus.Implementation
+{
+    using System;
+    using System.IO;
+    using OpenCensus.Stats;
+
+    /// <summary>
+    /// Utility class to write metrics data to the provided Stream
+    /// </summary>
+    internal static class MetricsWriter
+    {
+        /// <summary>
+        /// Writes the Prometheus Metrics in the given IViewManager to the given Stream
+        /// </summary>
+        internal static void WriteMetrics(Stream stream, IViewManager viewManager)
+        {
+            using (var writer = new StreamWriter(stream))
+            {
+                foreach (var view in viewManager.AllExportedViews)
+                {
+                    var data = viewManager.GetView(view.Name);
+
+                    var builder = new PrometheusMetricBuilder()
+                        .WithName(data.View.Name.AsString)
+                        .WithDescription(data.View.Description);
+
+                    builder = data.View.Aggregation.Match<PrometheusMetricBuilder>(
+                        (agg) => { return builder.WithType("gauge"); }, // Func<ISum, M> p0
+                        (agg) => { return builder.WithType("counter"); }, // Func< ICount, M > p1,
+                        (agg) => { return builder.WithType("histogram"); }, // Func<IMean, M> p2,
+                        (agg) => { return builder.WithType("histogram"); }, // Func< IDistribution, M > p3,
+                        (agg) => { return builder.WithType("gauge"); }, // Func<ILastValue, M> p4,
+                        (agg) => { return builder.WithType("gauge"); }); // Func< IAggregation, M > p6);
+
+                    foreach (var value in data.AggregationMap)
+                    {
+                        var metricValueBuilder = builder.AddValue();
+
+                        // TODO: This is not optimal. Need to refactor to split builder into separate functions
+                        metricValueBuilder = value.Value.Match<PrometheusMetricBuilder.PrometheusMetricValueBuilder>(
+                            metricValueBuilder.WithValue,
+                            metricValueBuilder.WithValue,
+                            metricValueBuilder.WithValue,
+                            metricValueBuilder.WithValue,
+                            metricValueBuilder.WithValue,
+                            metricValueBuilder.WithValue,
+                            metricValueBuilder.WithValue,
+                            metricValueBuilder.WithValue);
+
+                        for (int i = 0; i < value.Key.Values.Count; i++)
+                        {
+                            metricValueBuilder.WithLabel(data.View.Columns[i].Name, value.Key.Values[i].AsString);
+                        }
+                    }
+
+                    builder.Write(writer);
+                }
+            }
+        }
+    }
+}

--- a/src/OpenCensus.Exporter.Prometheus/Implementation/MetricsWriter.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Implementation/MetricsWriter.cs
@@ -28,7 +28,7 @@ namespace OpenCensus.Exporter.Prometheus.Implementation
         /// <summary>
         /// Writes the Prometheus Metrics in the given IViewManager to the given Stream
         /// </summary>
-        internal static void WriteMetrics(Stream stream, IViewManager viewManager)
+        internal static void Write(Stream stream, IViewManager viewManager)
         {
             using (var writer = new StreamWriter(stream))
             {

--- a/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddleware.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddleware.cs
@@ -35,9 +35,9 @@ namespace OpenCensus.Exporter.Prometheus.Middleware
 
         public PrometheusExporterMiddleware(RequestDelegate next, PrometheusMiddlewareOptions options, IViewManager viewManager)
         {
-            this.options = options;
-            this.viewManager = viewManager;
-            this.next = next;
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.viewManager = viewManager ?? throw new ArgumentNullException(nameof(viewManager));
+            this.next = next ?? throw new ArgumentNullException(nameof(next));
         }
 
         public async Task InvokeAsync(HttpContext ctx)

--- a/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddleware.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddleware.cs
@@ -1,0 +1,63 @@
+// <copyright file="PrometheusExporterMiddleware.cs" company="OpenCensus Authors">
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenCensus.Exporter.Prometheus.Middleware
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Http;
+    using OpenCensus.Exporter.Prometheus.Implementation;
+    using OpenCensus.Stats;
+
+    public class PrometheusExporterMiddleware
+    {
+        private readonly RequestDelegate next;
+
+        private readonly IViewManager viewManager;
+
+        private readonly PrometheusMiddlewareOptions options;
+
+        public PrometheusExporterMiddleware(RequestDelegate next, PrometheusMiddlewareOptions options, IViewManager viewManager)
+        {
+            this.options = options;
+            this.viewManager = viewManager;
+            this.next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext ctx)
+        {
+            // Check the request for the given url path
+            if (ctx.Request.Path.Equals(this.options.Path))
+            {
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = PrometheusMetricBuilder.ContentType;
+                using (var output = ctx.Response.Body)
+                {
+                    MetricsWriter.WriteMetrics(output, this.viewManager);
+                }
+
+                // Handle the request. Do not call next
+                return;
+            }
+
+            // Call the next delegate/middleware in the pipeline
+            await this.next(ctx);
+        }
+    }
+}

--- a/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddleware.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddleware.cs
@@ -43,7 +43,7 @@ namespace OpenCensus.Exporter.Prometheus.Middleware
         public async Task InvokeAsync(HttpContext ctx)
         {
             // Check the request for the given url path
-            if (ctx.Request.Path.Equals(this.options.Path))
+            if (ctx.Request.Path.Equals(this.options?.Path))
             {
                 ctx.Response.StatusCode = 200;
                 ctx.Response.ContentType = PrometheusMetricBuilder.ContentType;

--- a/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddleware.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddleware.cs
@@ -49,7 +49,7 @@ namespace OpenCensus.Exporter.Prometheus.Middleware
                 ctx.Response.ContentType = PrometheusMetricBuilder.ContentType;
                 using (var output = ctx.Response.Body)
                 {
-                    MetricsWriter.WriteMetrics(output, this.viewManager);
+                    MetricsWriter.Write(output, this.viewManager);
                 }
 
                 // Handle the request. Do not call next

--- a/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddlewareExtensions.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusExporterMiddlewareExtensions.cs
@@ -1,0 +1,42 @@
+// <copyright file="PrometheusExporterMiddlewareExtensions.cs" company="OpenCensus Authors">
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace OpenCensus.Exporter.Prometheus.Middleware
+{
+    using System;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Http;
+    using OpenCensus.Exporter.Prometheus.Implementation;
+    using OpenCensus.Stats;
+
+    /// <summary>
+    /// Adds Prometheus Export capabilities
+    /// </summary>
+    public static class PrometheusExporterMiddlewareExtensions
+    {
+        /// <summary>
+        /// Adds PrometheusExporterMiddleware to the given IApplicationBuilder
+        /// </summary>
+        public static IApplicationBuilder UsePrometheusExporter(
+            this IApplicationBuilder builder, PrometheusMiddlewareOptions options, IViewManager viewManager)
+        {
+            return builder.UseMiddleware<PrometheusExporterMiddleware>(options, viewManager);
+        }
+    }
+}

--- a/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusMiddlewareOptions.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Middleware/PrometheusMiddlewareOptions.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenCensus Authors">
+// <copyright file="PrometheusMiddlewareOptions.cs" company="OpenCensus Authors">
 // Copyright 2018, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,3 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
+namespace OpenCensus.Exporter.Prometheus
+{
+    using System;
+
+    /// <summary>
+    /// Options to run prometheus exporter.
+    /// </summary>
+    public class PrometheusMiddlewareOptions
+    {
+        /// <summary>
+        /// Gets or sets the path to respond on. Typically "/metrics".
+        /// </summary>
+        public string Path { get; set; }
+    }
+}

--- a/src/OpenCensus.Exporter.Prometheus/OpenCensus.Exporter.Prometheus.csproj
+++ b/src/OpenCensus.Exporter.Prometheus/OpenCensus.Exporter.Prometheus.csproj
@@ -19,6 +19,8 @@
 
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
     <ProjectReference Include="..\OpenCensus.Abstractions\OpenCensus.Abstractions.csproj" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>All</PrivateAssets>

--- a/test/TestPrometheusMiddleware.AspNetCore.2.1/Controllers/ValuesController.cs
+++ b/test/TestPrometheusMiddleware.AspNetCore.2.1/Controllers/ValuesController.cs
@@ -1,0 +1,85 @@
+﻿// <copyright file="ValuesController.cs" company="OpenCensus Authors">
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+namespace TestPrometheusMiddleware.AspNetCore._2._0.Controllers
+{
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Mvc;
+    using OpenCensus.Exporter.Prometheus;
+    using OpenCensus.Stats;
+    using OpenCensus.Stats.Aggregations;
+    using OpenCensus.Stats.Measures;
+    using OpenCensus.Tags;
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+
+    [Route("api/[controller]")]
+    public class ValuesController : Controller
+    {
+        private static long MiB = 1 << 20;
+
+        private static readonly IMeasureLong ValueSize = MeasureLong.Create("my.org/measure/values_size", "size of processed values", "By");
+
+        private static readonly ITagKey FrontendKey = TagKey.Create("my.org/keys/frontend");
+
+        private static readonly IViewName ValueSizeViewName = ViewName.Create("my.org/views/value_size");
+        private static readonly IView ValueSizeView = OpenCensus.Stats.View.Create(
+                   ValueSizeViewName,
+                   "processed value size over time",
+                   ValueSize,
+                   Distribution.Create(BucketBoundaries.Create(new List<double>() { 0.0, 16.0 * MiB, 256.0 * MiB })),
+                   new List<ITagKey>() { FrontendKey });
+
+        private readonly IStatsRecorder recorder;
+
+        private readonly ITagger tagger;
+
+        public ValuesController(IStatsRecorder statsRecorder, ITagger tagger, IViewManager viewManager) : base()
+        {
+            viewManager.RegisterView(ValueSizeView);
+            this.recorder = statsRecorder;
+            this.tagger = tagger;
+        }
+
+        // GET api/values
+        [HttpGet]
+        public IEnumerable<string> Get()
+        {
+            var retval = new List<string>();
+            var tagContextBuilder = tagger.CurrentBuilder.Put(FrontendKey, TagValue.Create("mobile-ios9.3.5"));
+            using (var scopedTags = tagContextBuilder.BuildScoped())
+            {
+                Random r = new Random();
+                for (int i = 0; i < r.Next(0, 100); i++)
+                {
+                    retval.Add($"value{i}");
+                }
+                this.recorder.NewMeasureMap().Put(ValueSize, string.Join(",", retval).Length * MiB).Record();
+            }
+            return retval;
+        }
+
+        // GET api/values/5
+        [HttpGet("{id}")]
+        public string Get(int id)
+        {
+            return "value";
+        }
+    }
+}

--- a/test/TestPrometheusMiddleware.AspNetCore.2.1/Controllers/ValuesController.cs
+++ b/test/TestPrometheusMiddleware.AspNetCore.2.1/Controllers/ValuesController.cs
@@ -58,6 +58,9 @@ namespace TestPrometheusMiddleware.AspNetCore._2._0.Controllers
         }
 
         // GET api/values
+        /// <summary>
+        /// Returns a pseudorandom set of strings of format value{i} where i is between 1 and 100
+        /// </summary>
         [HttpGet]
         public IEnumerable<string> Get()
         {

--- a/test/TestPrometheusMiddleware.AspNetCore.2.1/Program.cs
+++ b/test/TestPrometheusMiddleware.AspNetCore.2.1/Program.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AssemblyInfo.cs" company="OpenCensus Authors">
+﻿// <copyright file="Program.cs" company="OpenCensus Authors">
 // Copyright 2018, OpenCensus Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,3 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
+
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace TestPrometheusMiddleware.AspNetCore._2._0
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/test/TestPrometheusMiddleware.AspNetCore.2.1/Startup.cs
+++ b/test/TestPrometheusMiddleware.AspNetCore.2.1/Startup.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="Startup.cs" company="OpenCensus Authors">
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenCensus.Stats;
+using OpenCensus.Tags;
+using System.Net.Http;
+using OpenCensus.Exporter.Prometheus.Middleware;
+using OpenCensus.Exporter.Prometheus;
+
+
+namespace TestPrometheusMiddleware.AspNetCore._2._0
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+            services.AddSingleton<IViewManager>(Stats.ViewManager);
+            services.AddSingleton<IStatsRecorder>(Stats.StatsRecorder);
+            services.AddSingleton<ITagger>(Tags.Tagger);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UsePrometheusExporter(new PrometheusMiddlewareOptions() { Path = "/metrics" }, Stats.ViewManager);
+            app.UseMvc();
+        }
+    }
+}

--- a/test/TestPrometheusMiddleware.AspNetCore.2.1/TestPrometheusMiddleware.AspNetCore.2.0.csproj
+++ b/test/TestPrometheusMiddleware.AspNetCore.2.1/TestPrometheusMiddleware.AspNetCore.2.0.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'OpenCensus.sln'))\build\Common.test.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="wwwroot\**" />
+    <Content Remove="wwwroot\**" />
+    <EmbeddedResource Remove="wwwroot\**" />
+    <None Remove="wwwroot\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\OpenCensus\OpenCensus.csproj" />
+    <ProjectReference Include="..\..\src\OpenCensus.Exporter.Prometheus\OpenCensus.Exporter.Prometheus.csproj"/>
+
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/test/TestPrometheusMiddleware.AspNetCore.2.1/appsettings.Development.json
+++ b/test/TestPrometheusMiddleware.AspNetCore.2.1/appsettings.Development.json
@@ -1,0 +1,10 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/test/TestPrometheusMiddleware.AspNetCore.2.1/appsettings.json
+++ b/test/TestPrometheusMiddleware.AspNetCore.2.1/appsettings.json
@@ -1,0 +1,15 @@
+﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "Debug": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    },
+    "Console": {
+      "LogLevel": {
+        "Default": "Warning"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Refactors the writing of metrics to a common utility class in
Implementation.

Removes the `assembly: System.CLSCompliant(true)]` directive from
OpenCensus.Exporter.Prometheus to allow support for non-CLS  code (which
are the MVC types).

Adds a test/example Application, TestPrometheusMiddleware.AspNetCore.2.0,
which shows the middleware working in an example MVC application.

Closes #65 