### PR TITLE
Strip out ScopeID from addresses before using in span

### DIFF
--- a/src/OpenCensus.Exporter.Zipkin/Implementation/TraceExporterHandler.cs
+++ b/src/OpenCensus.Exporter.Zipkin/Implementation/TraceExporterHandler.cs
@@ -254,7 +254,8 @@ namespace OpenCensus.Exporter.Zipkin.Implementation
                     {
                         if (addr.AddressFamily.Equals(family))
                         {
-                            result = addr.ToString();
+                            var sanitizedAddress = new IPAddress(addr.GetAddressBytes()); // Construct address sans ScopeID
+                            result = sanitizedAddress.ToString();
 
                             break;
                         }


### PR DESCRIPTION
By default [`IPAddress.ToString()`](https://docs.microsoft.com/en-us/dotnet/api/system.net.ipaddress.tostring?view=netcore-2.1) Includes the [Scope ID](https://docs.microsoft.com/en-us/dotnet/api/system.net.ipaddress.scopeid?view=netcore-2.1) for the address. For instance, on my computer, spans from the opencensus-csharp library have the IPv6 address serialized as `"ipv6":"fe80::bb:d8cc:2f00:a772%8"` (notice the `%8` at the end). According to [RFC-6874](https://tools.ietf.org/html/rfc6874), the Scope ID (Zone ID) should only be used in the local context.

This problem surfaced when publishing spans to the Zipkin endpoint for [Jaeger](http://jaegertracing.io/), which expects the addresses to be deserializable into an [net.IP](https://golang.org/pkg/net/#IP) object, which (correctly) does not include the zone ID.

This PR creates an `IPAddress` without the scope ID for serialization purpose.