### PR TITLE
#46 - Span.Kind API set early

### DIFF
--- a/src/OpenCensus.Abstractions/Trace/ISpanBuilder.cs
+++ b/src/OpenCensus.Abstractions/Trace/ISpanBuilder.cs
@@ -25,11 +25,6 @@ namespace OpenCensus.Trace
     public interface ISpanBuilder
     {
         /// <summary>
-        /// Gets the SpanKind for the spans produced by this builder.
-        /// </summary>
-        SpanKind Kind { get; }
-
-        /// <summary>
         /// Set the sampler for the span.
         /// </summary>
         /// <param name="sampler">Sampler to use to build span.</param>

--- a/src/OpenCensus.Abstractions/Trace/ISpanBuilder.cs
+++ b/src/OpenCensus.Abstractions/Trace/ISpanBuilder.cs
@@ -25,6 +25,11 @@ namespace OpenCensus.Trace
     public interface ISpanBuilder
     {
         /// <summary>
+        /// Gets the SpanKind for the spans produced by this builder.
+        /// </summary>
+        SpanKind Kind { get; }
+
+        /// <summary>
         /// Set the sampler for the span.
         /// </summary>
         /// <param name="sampler">Sampler to use to build span.</param>

--- a/src/OpenCensus.Abstractions/Trace/ITracer.cs
+++ b/src/OpenCensus.Abstractions/Trace/ITracer.cs
@@ -39,23 +39,26 @@ namespace OpenCensus.Trace
         /// Gets the span builder for the span with the given name.
         /// </summary>
         /// <param name="spanName">Span name.</param>
+        /// <param name="spanKind">Span kind.</param>
         /// <returns>Span builder for the span with the given name.</returns>
-        ISpanBuilder SpanBuilder(string spanName);
+        ISpanBuilder SpanBuilder(string spanName, SpanKind spanKind = SpanKind.Unspecified);
 
         /// <summary>
         /// Gets the span builder for the span with the given name and parent.
         /// </summary>
         /// <param name="spanName">Span name.</param>
+        /// <param name="spanKind">Span kind.</param>
         /// <param name="parent">Parent of the span.</param>
         /// <returns>Span builder for the span with the given name and specified parent.</returns>
-        ISpanBuilder SpanBuilderWithExplicitParent(string spanName, ISpan parent = null);
+        ISpanBuilder SpanBuilderWithExplicitParent(string spanName, SpanKind spanKind = SpanKind.Unspecified, ISpan parent = null);
 
         /// <summary>
         /// Gets the span builder for the span with the give name and remote parent context.
         /// </summary>
         /// <param name="spanName">Span name.</param>
+        /// <param name="spanKind">Span kind.</param>
         /// <param name="remoteParentSpanContext">Remote parent context extracted from the wire.</param>
         /// <returns>Span builder for the span with the given name and specified parent span context.</returns>
-        ISpanBuilder SpanBuilderWithRemoteParent(string spanName, ISpanContext remoteParentSpanContext = null);
+        ISpanBuilder SpanBuilderWithRemoteParent(string spanName, SpanKind spanKind = SpanKind.Unspecified, ISpanContext remoteParentSpanContext = null);
     }
 }

--- a/src/OpenCensus.Abstractions/Trace/SpanExtensions.cs
+++ b/src/OpenCensus.Abstractions/Trace/SpanExtensions.cs
@@ -22,28 +22,6 @@ namespace OpenCensus.Trace
     public static class SpanExtensions
     {
         /// <summary>
-        /// Helper method that sets span kind to client.
-        /// </summary>
-        /// <param name="span">Span to fill out.</param>
-        /// <returns>Span set client span.</returns>
-        public static ISpan PutClientSpanKindAttribute(this ISpan span)
-        {
-            span.Kind = SpanKind.Client;
-            return span;
-        }
-
-        /// <summary>
-        /// Helper method that sets span kind to server.
-        /// </summary>
-        /// <param name="span">Span to fill out.</param>
-        /// <returns>Span set server span.</returns>
-        public static ISpan PutServerSpanKindAttribute(this ISpan span)
-        {
-            span.Kind = SpanKind.Server;
-            return span;
-        }
-
-        /// <summary>
         /// Helper method that populates span properties from http method according
         /// to https://github.com/census-instrumentation/opencensus-specs/blob/4954074adf815f437534457331178194f6847ff9/trace/HTTP.md.
         /// </summary>

--- a/src/OpenCensus.Collector.AspNetCore/Implementation/HttpInListener.cs
+++ b/src/OpenCensus.Collector.AspNetCore/Implementation/HttpInListener.cs
@@ -62,7 +62,7 @@ namespace OpenCensus.Collector.AspNetCore.Implementation
             string path = (request.PathBase.HasValue || request.Path.HasValue) ? (request.PathBase + request.Path).ToString() : "/";
 
             ISpan span = null;
-            this.Tracer.SpanBuilderWithRemoteParent(path, ctx).SetSampler(this.Sampler).StartScopedSpan(out span);
+            this.Tracer.SpanBuilderWithRemoteParent(path, SpanKind.Server, ctx).SetSampler(this.Sampler).StartScopedSpan(out span);
             if (span == null)
             {
                 // Debug.WriteLine("span is null");
@@ -71,7 +71,6 @@ namespace OpenCensus.Collector.AspNetCore.Implementation
 
             // Note, route is missing at this stage. It will be available later
 
-            span.PutServerSpanKindAttribute();
             span.PutHttpHostAttribute(request.Host.Host, request.Host.Port ?? 80);
             span.PutHttpMethodAttribute(request.Method);
             span.PutHttpPathAttribute(path);

--- a/src/OpenCensus.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
+++ b/src/OpenCensus.Collector.Dependencies/Implementation/HttpHandlerDiagnosticListener.cs
@@ -56,8 +56,7 @@ namespace OpenCensus.Collector.Dependencies.Implementation
                 return;
             }
 
-            this.Tracer.SpanBuilder(request.RequestUri.AbsolutePath).SetSampler(this.Sampler).StartScopedSpan(out ISpan span);
-            span.PutClientSpanKindAttribute();
+            this.Tracer.SpanBuilder(request.RequestUri.AbsolutePath, SpanKind.Client).SetSampler(this.Sampler).StartScopedSpan(out ISpan span);
             span.PutHttpMethodAttribute(request.Method.ToString());
             span.PutHttpHostAttribute(request.RequestUri.Host, request.RequestUri.Port);
             span.PutHttpPathAttribute(request.RequestUri.AbsolutePath);

--- a/src/OpenCensus/Trace/NoopSpanBuilder.cs
+++ b/src/OpenCensus/Trace/NoopSpanBuilder.cs
@@ -22,7 +22,7 @@ namespace OpenCensus.Trace
 
     public class NoopSpanBuilder : SpanBuilderBase
     {
-        private NoopSpanBuilder(string name)
+        private NoopSpanBuilder(string name, SpanKind kind) : base(kind)
         {
             if (name == null)
             {
@@ -50,14 +50,14 @@ namespace OpenCensus.Trace
             return this;
         }
 
-        internal static ISpanBuilder CreateWithParent(string spanName, ISpan parent = null)
+        internal static ISpanBuilder CreateWithParent(string spanName, SpanKind kind, ISpan parent = null)
         {
-            return new NoopSpanBuilder(spanName);
+            return new NoopSpanBuilder(spanName, kind);
         }
 
-        internal static ISpanBuilder CreateWithRemoteParent(string spanName, ISpanContext remoteParentSpanContext = null)
+        internal static ISpanBuilder CreateWithRemoteParent(string spanName, SpanKind kind, ISpanContext remoteParentSpanContext = null)
         {
-            return new NoopSpanBuilder(spanName);
+            return new NoopSpanBuilder(spanName, kind);
         }
     }
 }

--- a/src/OpenCensus/Trace/NoopTracer.cs
+++ b/src/OpenCensus/Trace/NoopTracer.cs
@@ -22,14 +22,14 @@ namespace OpenCensus.Trace
         {
         }
 
-        public override ISpanBuilder SpanBuilderWithExplicitParent(string spanName, ISpan parent)
+        public override ISpanBuilder SpanBuilderWithExplicitParent(string spanName, SpanKind spanKind = SpanKind.Unspecified, ISpan parent = null)
         {
-            return NoopSpanBuilder.CreateWithParent(spanName, parent);
+            return NoopSpanBuilder.CreateWithParent(spanName, spanKind, parent);
         }
 
-        public override ISpanBuilder SpanBuilderWithRemoteParent(string spanName, ISpanContext remoteParentSpanContext)
+        public override ISpanBuilder SpanBuilderWithRemoteParent(string spanName, SpanKind spanKind = SpanKind.Unspecified, ISpanContext remoteParentSpanContext = null)
         {
-            return NoopSpanBuilder.CreateWithRemoteParent(spanName, remoteParentSpanContext);
+            return NoopSpanBuilder.CreateWithRemoteParent(spanName, spanKind, remoteParentSpanContext);
         }
     }
 }

--- a/src/OpenCensus/Trace/SpanBuilder.cs
+++ b/src/OpenCensus/Trace/SpanBuilder.cs
@@ -25,11 +25,7 @@ namespace OpenCensus.Trace
 
     public class SpanBuilder : SpanBuilderBase
     {
-        internal SpanBuilder()
-        {
-        }
-
-        private SpanBuilder(string name, SpanBuilderOptions options, ISpanContext remoteParentSpanContext = null, ISpan parent = null)
+        private SpanBuilder(string name, SpanKind kind, SpanBuilderOptions options, ISpanContext remoteParentSpanContext = null, ISpan parent = null) : base(kind)
         {
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.Parent = parent;
@@ -107,14 +103,14 @@ namespace OpenCensus.Trace
             return this;
         }
 
-        internal static ISpanBuilder CreateWithParent(string spanName, ISpan parent, SpanBuilderOptions options)
+        internal static ISpanBuilder CreateWithParent(string spanName, SpanKind kind, ISpan parent, SpanBuilderOptions options)
         {
-            return new SpanBuilder(spanName, options, null, parent);
+            return new SpanBuilder(spanName, kind, options, null, parent);
         }
 
-        internal static ISpanBuilder CreateWithRemoteParent(string spanName, ISpanContext remoteParentSpanContext, SpanBuilderOptions options)
+        internal static ISpanBuilder CreateWithRemoteParent(string spanName, SpanKind kind, ISpanContext remoteParentSpanContext, SpanBuilderOptions options)
         {
-            return new SpanBuilder(spanName, options, remoteParentSpanContext, null);
+            return new SpanBuilder(spanName, kind, options, remoteParentSpanContext, null);
         }
 
         private static bool IsAnyParentLinkSampled(IEnumerable<ISpan> parentLinks)
@@ -234,6 +230,7 @@ namespace OpenCensus.Trace
                         timestampConverter,
                         this.Options.Clock);
             LinkSpans(span, parentLinks);
+            span.Kind = this.Kind;
             return span;
         }
     }

--- a/src/OpenCensus/Trace/SpanBuilderBase.cs
+++ b/src/OpenCensus/Trace/SpanBuilderBase.cs
@@ -21,6 +21,15 @@ namespace OpenCensus.Trace
 
     public abstract class SpanBuilderBase : ISpanBuilder
     {
+        private SpanBuilderBase()
+        {
+        }
+
+        protected SpanBuilderBase(SpanKind kind)
+        {
+            this.Kind = kind;
+        }
+
         public abstract ISpanBuilder SetSampler(ISampler sampler);
 
         public abstract ISpanBuilder SetParentLinks(IEnumerable<ISpan> parentLinks);
@@ -39,5 +48,7 @@ namespace OpenCensus.Trace
             currentSpan = this.StartSpan();
             return CurrentSpanUtils.WithSpan(currentSpan, true);
         }
+
+        public SpanKind Kind { get; }
     }
 }

--- a/src/OpenCensus/Trace/SpanBuilderBase.cs
+++ b/src/OpenCensus/Trace/SpanBuilderBase.cs
@@ -25,6 +25,8 @@ namespace OpenCensus.Trace
         {
         }
 
+        protected SpanKind Kind { get; private set; }
+
         protected SpanBuilderBase(SpanKind kind)
         {
             this.Kind = kind;
@@ -48,7 +50,5 @@ namespace OpenCensus.Trace
             currentSpan = this.StartSpan();
             return CurrentSpanUtils.WithSpan(currentSpan, true);
         }
-
-        public SpanKind Kind { get; }
     }
 }

--- a/src/OpenCensus/Trace/Tracer.cs
+++ b/src/OpenCensus/Trace/Tracer.cs
@@ -29,14 +29,14 @@ namespace OpenCensus.Trace
             this.spanBuilderOptions = new SpanBuilderOptions(randomGenerator, startEndHandler, clock, traceConfig);
         }
 
-        public override ISpanBuilder SpanBuilderWithExplicitParent(string spanName, ISpan parent = null)
+        public override ISpanBuilder SpanBuilderWithExplicitParent(string spanName, SpanKind spanKind = SpanKind.Unspecified, ISpan parent = null)
         {
-            return Trace.SpanBuilder.CreateWithParent(spanName, parent, this.spanBuilderOptions);
+            return Trace.SpanBuilder.CreateWithParent(spanName, spanKind, parent, this.spanBuilderOptions);
         }
 
-        public override ISpanBuilder SpanBuilderWithRemoteParent(string spanName, ISpanContext remoteParentSpanContext = null)
+        public override ISpanBuilder SpanBuilderWithRemoteParent(string spanName, SpanKind spanKind = SpanKind.Unspecified, ISpanContext remoteParentSpanContext = null)
         {
-            return Trace.SpanBuilder.CreateWithRemoteParent(spanName, remoteParentSpanContext, this.spanBuilderOptions);
+            return Trace.SpanBuilder.CreateWithRemoteParent(spanName, spanKind, remoteParentSpanContext, this.spanBuilderOptions);
         }
     }
 }

--- a/src/OpenCensus/Trace/TracerBase.cs
+++ b/src/OpenCensus/Trace/TracerBase.cs
@@ -53,13 +53,13 @@ namespace OpenCensus.Trace
 
         // public final Runnable withSpan(Span span, Runnable runnable)
         // public final <C> Callable<C> withSpan(Span span, final Callable<C> callable)
-        public ISpanBuilder SpanBuilder(string spanName)
+        public ISpanBuilder SpanBuilder(string spanName, SpanKind spanKind = SpanKind.Unspecified)
         {
-            return this.SpanBuilderWithExplicitParent(spanName, CurrentSpanUtils.CurrentSpan);
+            return this.SpanBuilderWithExplicitParent(spanName, spanKind, CurrentSpanUtils.CurrentSpan);
         }
 
-        public abstract ISpanBuilder SpanBuilderWithExplicitParent(string spanName, ISpan parent = null);
+        public abstract ISpanBuilder SpanBuilderWithExplicitParent(string spanName, SpanKind spanKind = SpanKind.Unspecified, ISpan parent = null);
 
-        public abstract ISpanBuilder SpanBuilderWithRemoteParent(string spanName, ISpanContext remoteParentSpanContext = null);
+        public abstract ISpanBuilder SpanBuilderWithRemoteParent(string spanName, SpanKind spanKind = SpanKind.Unspecified, ISpanContext remoteParentSpanContext = null);
     }
 }

--- a/test/OpenCensus.Tests/Impl/Trace/SpanBuilderBaseTest.cs
+++ b/test/OpenCensus.Tests/Impl/Trace/SpanBuilderBaseTest.cs
@@ -24,7 +24,7 @@ namespace OpenCensus.Trace.Test
     public class SpanBuilderBaseTest
     {
         private ITracer tracer;
-        private Mock<SpanBuilderBase> spanBuilder = new Mock<SpanBuilderBase>();
+        private Mock<SpanBuilderBase> spanBuilder = new Mock<SpanBuilderBase>(SpanKind.Unspecified);
         private Mock<SpanBase> span = new Mock<SpanBase>();
 
         public SpanBuilderBaseTest()

--- a/test/OpenCensus.Tests/Impl/Trace/SpanBuilderTest.cs
+++ b/test/OpenCensus.Tests/Impl/Trace/SpanBuilderTest.cs
@@ -50,7 +50,7 @@ namespace OpenCensus.Trace.Test
         public void StartSpanNullParent()
         {
             ISpan span =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions).StartSpan();
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified,  null, spanBuilderOptions).StartSpan();
             Assert.True(span.Context.IsValid);
             Assert.True(span.Options.HasFlag(SpanOptions.RecordEvents));
             Assert.True(span.Context.TraceOptions.IsSampled);
@@ -65,7 +65,7 @@ namespace OpenCensus.Trace.Test
         public void StartSpanNullParentWithRecordEvents()
         {
             ISpan span =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.NeverSample)
                     .SetRecordEvents(true)
                     .StartSpan();
@@ -81,7 +81,7 @@ namespace OpenCensus.Trace.Test
         public void StartSpanNullParentNoRecordOptions()
         {
             ISpan span =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.NeverSample)
                     .StartSpan();
             Assert.True(span.Context.IsValid);
@@ -93,13 +93,13 @@ namespace OpenCensus.Trace.Test
         public void StartChildSpan()
         {
             ISpan rootSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions).StartSpan();
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions).StartSpan();
             Assert.True(rootSpan.Context.IsValid);
             Assert.True(rootSpan.Options.HasFlag(SpanOptions.RecordEvents));
             Assert.True(rootSpan.Context.TraceOptions.IsSampled);
             Assert.False(((Span)rootSpan).ToSpanData().HasRemoteParent);
             ISpan childSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, rootSpan, spanBuilderOptions).StartSpan();
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, rootSpan, spanBuilderOptions).StartSpan();
             Assert.True(childSpan.Context.IsValid);
             Assert.Equal(rootSpan.Context.TraceId, childSpan.Context.TraceId);
             Assert.Equal(rootSpan.Context.SpanId, ((Span)childSpan).ToSpanData().ParentSpanId);
@@ -111,7 +111,7 @@ namespace OpenCensus.Trace.Test
         public void StartRemoteSpan_NullParent()
         {
             ISpan span =
-                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, null, spanBuilderOptions).StartSpan();
+                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions).StartSpan();
             Assert.True(span.Context.IsValid);
             Assert.True(span.Options.HasFlag(SpanOptions.RecordEvents));
             Assert.True(span.Context.TraceOptions.IsSampled);
@@ -124,7 +124,7 @@ namespace OpenCensus.Trace.Test
         public void StartRemoteSpanInvalidParent()
         {
             ISpan span =
-                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, SpanContext.Invalid, spanBuilderOptions)
+                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, SpanKind.Unspecified, SpanContext.Invalid, spanBuilderOptions)
                     .StartSpan();
             Assert.True(span.Context.IsValid);
             Assert.True(span.Options.HasFlag(SpanOptions.RecordEvents));
@@ -143,7 +143,7 @@ namespace OpenCensus.Trace.Test
                     SpanId.GenerateRandomId(randomHandler),
                     TraceOptions.Default, Tracestate.Empty);
             ISpan span =
-                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, spanContext, spanBuilderOptions)
+                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, SpanKind.Unspecified, spanContext, spanBuilderOptions)
                     .StartSpan();
             Assert.True(span.Context.IsValid);
             Assert.Equal(spanContext.TraceId, span.Context.TraceId);
@@ -158,7 +158,7 @@ namespace OpenCensus.Trace.Test
         {
             // Apply given sampler before default sampler for root spans.
             ISpan rootSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.NeverSample)
                     .StartSpan();
             Assert.True(rootSpan.Context.IsValid);
@@ -170,7 +170,7 @@ namespace OpenCensus.Trace.Test
         {
             // Apply default sampler (always true in the tests) for root spans.
             ISpan rootSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions).StartSpan();
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions).StartSpan();
             Assert.True(rootSpan.Context.IsValid);
             Assert.True(rootSpan.Context.TraceOptions.IsSampled);
         }
@@ -179,14 +179,14 @@ namespace OpenCensus.Trace.Test
         public void StartRemoteChildSpan_WithSpecifiedSampler()
         {
             ISpan rootSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.AlwaysSample)
                     .StartSpan();
             Assert.True(rootSpan.Context.IsValid);
             Assert.True(rootSpan.Context.TraceOptions.IsSampled);
             // Apply given sampler before default sampler for spans with remote parent.
             ISpan childSpan =
-                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, rootSpan.Context, spanBuilderOptions)
+                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, SpanKind.Unspecified, rootSpan.Context, spanBuilderOptions)
                     .SetSampler(Samplers.NeverSample)
                     .StartSpan();
             Assert.True(childSpan.Context.IsValid);
@@ -198,14 +198,14 @@ namespace OpenCensus.Trace.Test
         public void StartRemoteChildSpan_WithoutSpecifiedSampler()
         {
             ISpan rootSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.NeverSample)
                     .StartSpan();
             Assert.True(rootSpan.Context.IsValid);
             Assert.False(rootSpan.Context.TraceOptions.IsSampled);
             // Apply default sampler (always true in the tests) for spans with remote parent.
             ISpan childSpan =
-                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, rootSpan.Context, spanBuilderOptions)
+                SpanBuilder.CreateWithRemoteParent(SPAN_NAME, SpanKind.Unspecified, rootSpan.Context, spanBuilderOptions)
                     .StartSpan();
             Assert.True(childSpan.Context.IsValid);
             Assert.Equal(rootSpan.Context.TraceId, childSpan.Context.TraceId);
@@ -216,14 +216,14 @@ namespace OpenCensus.Trace.Test
         public void StartChildSpan_WithSpecifiedSampler()
         {
             ISpan rootSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.AlwaysSample)
                     .StartSpan();
             Assert.True(rootSpan.Context.IsValid);
             Assert.True(rootSpan.Context.TraceOptions.IsSampled);
             // Apply the given sampler for child spans.
             ISpan childSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, rootSpan, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, rootSpan, spanBuilderOptions)
                     .SetSampler(Samplers.NeverSample)
                     .StartSpan();
             Assert.True(childSpan.Context.IsValid);
@@ -235,14 +235,14 @@ namespace OpenCensus.Trace.Test
         public void StartChildSpan_WithoutSpecifiedSampler()
         {
             ISpan rootSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.NeverSample)
                     .StartSpan();
             Assert.True(rootSpan.Context.IsValid);
             Assert.False(rootSpan.Context.TraceOptions.IsSampled);
             // Don't apply the default sampler (always true) for child spans.
             ISpan childSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, rootSpan, spanBuilderOptions).StartSpan();
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, rootSpan, spanBuilderOptions).StartSpan();
             Assert.True(childSpan.Context.IsValid);
             Assert.Equal(rootSpan.Context.TraceId, childSpan.Context.TraceId);
             Assert.False(childSpan.Context.TraceOptions.IsSampled);
@@ -252,18 +252,18 @@ namespace OpenCensus.Trace.Test
         public void StartChildSpan_SampledLinkedParent()
         {
             ISpan rootSpanUnsampled =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.NeverSample)
                     .StartSpan();
             Assert.False(rootSpanUnsampled.Context.TraceOptions.IsSampled);
             ISpan rootSpanSampled =
-                SpanBuilder.CreateWithParent(SPAN_NAME, null, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, null, spanBuilderOptions)
                     .SetSampler(Samplers.AlwaysSample)
                     .StartSpan();
             Assert.True(rootSpanSampled.Context.TraceOptions.IsSampled);
             // Sampled because the linked parent is sampled.
             ISpan childSpan =
-                SpanBuilder.CreateWithParent(SPAN_NAME, rootSpanUnsampled, spanBuilderOptions)
+                SpanBuilder.CreateWithParent(SPAN_NAME, SpanKind.Unspecified, rootSpanUnsampled, spanBuilderOptions)
                     .SetParentLinks(new List<ISpan>() { rootSpanSampled })
                     .StartSpan();
             Assert.True(childSpan.Context.IsValid);
@@ -303,6 +303,7 @@ namespace OpenCensus.Trace.Test
             ISpan childSpan =
                 SpanBuilder.CreateWithRemoteParent(
                         SPAN_NAME,
+                        SpanKind.Unspecified,
                         SpanContext.Create(
                             traceId,
                             SpanId.GenerateRandomId(randomHandler),
@@ -320,6 +321,7 @@ namespace OpenCensus.Trace.Test
             childSpan =
                 SpanBuilder.CreateWithRemoteParent(
                         SPAN_NAME,
+                        SpanKind.Unspecified,
                         SpanContext.Create(
                             traceId,
                             SpanId.GenerateRandomId(randomHandler),

--- a/test/OpenCensus.Tests/Impl/Trace/TracerBaseTest.cs
+++ b/test/OpenCensus.Tests/Impl/Trace/TracerBaseTest.cs
@@ -27,7 +27,7 @@ namespace OpenCensus.Trace.Test
         private static readonly ITracer noopTracer = TracerBase.NoopTracer;
         private static readonly string SPAN_NAME = "MySpanName";
         private TracerBase tracer = Mock.Of<TracerBase>();
-        private SpanBuilderBase spanBuilder = Mock.Of<SpanBuilderBase>();
+        private SpanBuilderBase spanBuilder = new Mock<SpanBuilderBase>(SpanKind.Unspecified).Object;
         private SpanBase span = Mock.Of<SpanBase>();
 
         public TracerBaseTest()
@@ -121,31 +121,31 @@ namespace OpenCensus.Trace.Test
         [Fact]
         public void SpanBuilderWithParentAndName_NullName()
         {
-            Assert.Throws<ArgumentNullException>(() => noopTracer.SpanBuilderWithExplicitParent(null, null));
+            Assert.Throws<ArgumentNullException>(() => noopTracer.SpanBuilderWithExplicitParent(spanName: null, parent: null));
         }
 
         [Fact]
         public void DefaultSpanBuilderWithParentAndName()
         {
-            Assert.Same(BlankSpan.Instance, noopTracer.SpanBuilderWithExplicitParent(SPAN_NAME, null).StartSpan());
+            Assert.Same(BlankSpan.Instance, noopTracer.SpanBuilderWithExplicitParent(SPAN_NAME, parent: null).StartSpan());
         }
 
         [Fact]
         public void spanBuilderWithRemoteParent_NullName()
         {
-            Assert.Throws<ArgumentNullException>(() => noopTracer.SpanBuilderWithRemoteParent(null, null));
+            Assert.Throws<ArgumentNullException>(() => noopTracer.SpanBuilderWithRemoteParent(null, remoteParentSpanContext: null));
         }
 
         [Fact]
         public void DefaultSpanBuilderWithRemoteParent_NullParent()
         {
-            Assert.Same(BlankSpan.Instance, noopTracer.SpanBuilderWithRemoteParent(SPAN_NAME, null).StartSpan());
+            Assert.Same(BlankSpan.Instance, noopTracer.SpanBuilderWithRemoteParent(SPAN_NAME, remoteParentSpanContext: null).StartSpan());
         }
 
         [Fact]
         public void DefaultSpanBuilderWithRemoteParent()
         {
-            Assert.Same(BlankSpan.Instance, noopTracer.SpanBuilderWithRemoteParent(SPAN_NAME, SpanContext.Invalid).StartSpan());
+            Assert.Same(BlankSpan.Instance, noopTracer.SpanBuilderWithRemoteParent(SPAN_NAME, remoteParentSpanContext: SpanContext.Invalid).StartSpan());
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace OpenCensus.Trace.Test
             try
             {
                 Assert.Same(span, tracer.CurrentSpan);
-                Mock.Get(tracer).Setup((tracer) => tracer.SpanBuilderWithExplicitParent(SPAN_NAME, span)).Returns(spanBuilder);
+                Mock.Get(tracer).Setup((tracer) => tracer.SpanBuilderWithExplicitParent(SPAN_NAME, SpanKind.Unspecified, span)).Returns(spanBuilder);
                 Assert.Same(spanBuilder, tracer.SpanBuilder(SPAN_NAME));
             }
             finally
@@ -171,7 +171,7 @@ namespace OpenCensus.Trace.Test
             try
             {
                 Assert.Same(BlankSpan.Instance, tracer.CurrentSpan);
-                Mock.Get(tracer).Setup((t) => t.SpanBuilderWithExplicitParent(SPAN_NAME, BlankSpan.Instance)).Returns(spanBuilder);
+                Mock.Get(tracer).Setup((t) => t.SpanBuilderWithExplicitParent(SPAN_NAME, SpanKind.Unspecified, BlankSpan.Instance)).Returns(spanBuilder);
                 Assert.Same(spanBuilder, tracer.SpanBuilder(SPAN_NAME));
             }
             finally

--- a/test/OpenCensus.Tests/Impl/Trace/TracerTest.cs
+++ b/test/OpenCensus.Tests/Impl/Trace/TracerTest.cs
@@ -40,14 +40,14 @@ namespace OpenCensus.Trace.Test
         [Fact]
         public void CreateSpanBuilder()
         {
-            ISpanBuilder spanBuilder = tracer.SpanBuilderWithExplicitParent(SPAN_NAME, BlankSpan.Instance);
+            ISpanBuilder spanBuilder = tracer.SpanBuilderWithExplicitParent(SPAN_NAME, parent: BlankSpan.Instance);
             Assert.IsType<SpanBuilder>(spanBuilder);
         }
 
         [Fact]
         public void CreateSpanBuilderWithRemoteParet()
         {
-            ISpanBuilder spanBuilder = tracer.SpanBuilderWithRemoteParent(SPAN_NAME, SpanContext.Invalid);
+            ISpanBuilder spanBuilder = tracer.SpanBuilderWithRemoteParent(SPAN_NAME, remoteParentSpanContext: SpanContext.Invalid);
             Assert.IsType<SpanBuilder>(spanBuilder);
         }
     }


### PR DESCRIPTION
Setting the Span.Kind early in the ctor of SpanBuilder, and using the same for all StartSpan from it thereafter.

#46