### PR TITLE
Item #64 - Replace usage of IList or List with readonly collections w…

### DIFF
--- a/src/OpenCensus.Abstractions/Stats/Aggregations/IDistributionData.cs
+++ b/src/OpenCensus.Abstractions/Stats/Aggregations/IDistributionData.cs
@@ -51,6 +51,6 @@ namespace OpenCensus.Stats.Aggregations
         /// <summary>
         /// Gets the counts in buckets.
         /// </summary>
-        IList<long> BucketCounts { get; }
+        IReadOnlyList<long> BucketCounts { get; }
     }
 }

--- a/src/OpenCensus.Abstractions/Stats/IBucketBoundaries.cs
+++ b/src/OpenCensus.Abstractions/Stats/IBucketBoundaries.cs
@@ -26,6 +26,6 @@ namespace OpenCensus.Stats
         /// <summary>
         /// Gets the list of boundaries for the distribution aggregator.
         /// </summary>
-        IList<double> Boundaries { get; }
+        IReadOnlyList<double> Boundaries { get; }
     }
 }

--- a/src/OpenCensus.Abstractions/Stats/IView.cs
+++ b/src/OpenCensus.Abstractions/Stats/IView.cs
@@ -47,6 +47,6 @@ namespace OpenCensus.Stats
         /// <summary>
         /// Gets the columns (dimensions) recorded by this view.
         /// </summary>
-        IList<ITagKey> Columns { get; }
+        IReadOnlyList<ITagKey> Columns { get; }
     }
 }

--- a/src/OpenCensus.Abstractions/Tags/TagValues.cs
+++ b/src/OpenCensus.Abstractions/Tags/TagValues.cs
@@ -18,14 +18,13 @@ namespace OpenCensus.Tags
 {
     using System.Collections.Generic;
     using OpenCensus.Abstractions.Utils;
-    using OpenCensus.Utils;
 
     /// <summary>
     /// Collection of tags.
     /// </summary>
     public sealed class TagValues
     {
-        private TagValues(IList<ITagValue> values)
+        private TagValues(IReadOnlyList<ITagValue> values)
         {
             this.Values = values;
         }
@@ -33,14 +32,14 @@ namespace OpenCensus.Tags
         /// <summary>
         /// Gets the collection of tag values.
         /// </summary>
-        public IList<ITagValue> Values { get; }
+        public IReadOnlyList<ITagValue> Values { get; }
 
         /// <summary>
         /// Create tag values out of list of tags.
         /// </summary>
         /// <param name="values">Values to create tag values from.</param>
         /// <returns>Resulting tag values collection.</returns>
-        public static TagValues Create(IList<ITagValue> values)
+        public static TagValues Create(IReadOnlyList<ITagValue> values)
         {
             return new TagValues(values);
         }

--- a/src/OpenCensus.Abstractions/Trace/Export/ISampledSpanStore.cs
+++ b/src/OpenCensus.Abstractions/Trace/Export/ISampledSpanStore.cs
@@ -51,13 +51,13 @@ namespace OpenCensus.Trace.Export
         /// Registers span names for collection.
         /// </summary>
         /// <param name="spanNames">List of span names.</param>
-        void RegisterSpanNamesForCollection(IList<string> spanNames);
+        void RegisterSpanNamesForCollection(IEnumerable<string> spanNames);
 
         /// <summary>
         /// Unregister span names for the collection.
         /// </summary>
         /// <param name="spanNames">Span names to unregister.</param>
-        void UnregisterSpanNamesForCollection(IList<string> spanNames);
+        void UnregisterSpanNamesForCollection(IEnumerable<string> spanNames);
 
         /// <summary>
         /// Consider span for sampling.

--- a/src/OpenCensus.Abstractions/Trace/Export/LinkList.cs
+++ b/src/OpenCensus.Abstractions/Trace/Export/LinkList.cs
@@ -22,7 +22,7 @@ namespace OpenCensus.Trace.Export
 
     public sealed class LinkList : ILinks
     {
-        internal LinkList(IList<ILink> links, int droppedLinksCount)
+        internal LinkList(IEnumerable<ILink> links, int droppedLinksCount)
         {
             this.Links = links ?? throw new ArgumentNullException("Null links");
             this.DroppedLinksCount = droppedLinksCount;
@@ -32,16 +32,16 @@ namespace OpenCensus.Trace.Export
 
         public IEnumerable<ILink> Links { get; }
 
-        public static LinkList Create(IList<ILink> links, int droppedLinksCount)
+        public static LinkList Create(IEnumerable<ILink> links, int droppedLinksCount)
         {
             if (links == null)
             {
                 throw new ArgumentNullException(nameof(links));
             }
 
-            List<ILink> copy = new List<ILink>(links);
+            IEnumerable<ILink> copy = new List<ILink>(links);
 
-            return new LinkList(copy.AsReadOnly(), droppedLinksCount);
+            return new LinkList(copy, droppedLinksCount);
         }
 
         /// <inheritdoc/>

--- a/src/OpenCensus.Abstractions/Trace/Export/SpanData.cs
+++ b/src/OpenCensus.Abstractions/Trace/Export/SpanData.cs
@@ -18,6 +18,7 @@ namespace OpenCensus.Trace.Export
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using OpenCensus.Common;
 
     public sealed class SpanData : ISpanData
@@ -43,9 +44,9 @@ namespace OpenCensus.Trace.Export
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.StartTimestamp = startTimestamp ?? throw new ArgumentNullException(nameof(startTimestamp));
             this.Attributes = attributes ?? Export.Attributes.Create(new Dictionary<string, IAttributeValue>(), 0);
-            this.Annotations = annotations ?? TimedEvents<IAnnotation>.Create(new List<ITimedEvent<IAnnotation>>(), 0);
-            this.MessageEvents = messageEvents ?? TimedEvents<IMessageEvent>.Create(new List<ITimedEvent<IMessageEvent>>(), 0);
-            this.Links = links ?? LinkList.Create(new List<ILink>(), 0);
+            this.Annotations = annotations ?? TimedEvents<IAnnotation>.Create(Enumerable.Empty<ITimedEvent<IAnnotation>>(), 0);
+            this.MessageEvents = messageEvents ?? TimedEvents<IMessageEvent>.Create(Enumerable.Empty<ITimedEvent<IMessageEvent>>(), 0);
+            this.Links = links ?? LinkList.Create(Enumerable.Empty<ILink>(), 0);
             this.ChildSpanCount = childSpanCount;
             this.Status = status;
             this.Kind = kind;

--- a/src/OpenCensus.Abstractions/Trace/Export/TimedEvents.cs
+++ b/src/OpenCensus.Abstractions/Trace/Export/TimedEvents.cs
@@ -39,9 +39,7 @@ namespace OpenCensus.Trace.Export
                 throw new ArgumentNullException(nameof(events));
             }
 
-            List<ITimedEvent<T>> ev = new List<ITimedEvent<T>>();
-            ev.AddRange(events);
-            return new TimedEvents<T>(ev.AsReadOnly(), droppedEventsCount);
+            return new TimedEvents<T>(events, droppedEventsCount);
         }
 
         /// <inheritdoc/>

--- a/src/OpenCensus.Abstractions/Trace/TraceState.cs
+++ b/src/OpenCensus.Abstractions/Trace/TraceState.cs
@@ -18,6 +18,7 @@ namespace OpenCensus.Trace
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Tracestate entries allowing different vendors to participate in a trace.
@@ -28,7 +29,7 @@ namespace OpenCensus.Trace
         /// <summary>
         /// An instance of empty tracestate.
         /// </summary>
-        public static readonly Tracestate Empty = new Tracestate(new List<Entry>());
+        public static readonly Tracestate Empty = new Tracestate(Enumerable.Empty<Entry>());
 
         private const int KeyMaxSize = 256;
         private const int ValueMaxSize = 256;
@@ -185,7 +186,7 @@ namespace OpenCensus.Trace
             return true;
         }
 
-        private static Tracestate Create(List<Entry> entries)
+        private static Tracestate Create(ICollection<Entry> entries)
         {
             // TODO: discard last entries instead of throwing
 
@@ -253,7 +254,7 @@ namespace OpenCensus.Trace
         {
             private readonly Tracestate parent;
 
-            private List<Entry> entries;
+            private IList<Entry> entries;
 
             internal TracestateBuilder(Tracestate parent)
             {

--- a/src/OpenCensus.Collector.StackExchangeRedis/Implementation/RedisProfilerEntryToSpanConverter.cs
+++ b/src/OpenCensus.Collector.StackExchangeRedis/Implementation/RedisProfilerEntryToSpanConverter.cs
@@ -25,7 +25,7 @@ namespace OpenCensus.Collector.StackExchangeRedis.Implementation
 
     internal static class RedisProfilerEntryToSpanConverter
     {
-        public static void DrainSession(ISpan parentSpan, IEnumerable<IProfiledCommand> sessionCommands, ISampler sampler, IList<ISpanData> spans)
+        public static void DrainSession(ISpan parentSpan, IEnumerable<IProfiledCommand> sessionCommands, ISampler sampler, ICollection<ISpanData> spans)
         {
             var parentContext = parentSpan?.Context ?? SpanContext.Invalid;
 

--- a/src/OpenCensus.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
+++ b/src/OpenCensus.Exporter.Prometheus/Implementation/PrometheusMetricBuilder.cs
@@ -58,7 +58,7 @@ namespace OpenCensus.Exporter.Prometheus.Implementation
             '_',
         };
 
-        private readonly IList<PrometheusMetricValueBuilder> values = new List<PrometheusMetricValueBuilder>();
+        private readonly ICollection<PrometheusMetricValueBuilder> values = new List<PrometheusMetricValueBuilder>();
 
         private string name;
         private string description;
@@ -330,7 +330,7 @@ namespace OpenCensus.Exporter.Prometheus.Implementation
 
         internal class PrometheusMetricValueBuilder
         {
-            public readonly IList<Tuple<string, string>> Labels = new List<Tuple<string, string>>();
+            public readonly ICollection<Tuple<string, string>> Labels = new List<Tuple<string, string>>();
             public double Value;
 
             public PrometheusMetricValueBuilder WithLabel(string name, string value)

--- a/src/OpenCensus.Exporter.Stackdriver/Implementation/MetricsConversions.cs
+++ b/src/OpenCensus.Exporter.Stackdriver/Implementation/MetricsConversions.cs
@@ -172,7 +172,7 @@ namespace OpenCensus.Exporter.Stackdriver.Implementation
         /// </summary>
         /// <param name="bucketCounts">Opencensus list of counts</param>
         /// <returns></returns>
-        private static IList<long> CreateBucketCounts(IList<long> bucketCounts)
+        private static IEnumerable<long> CreateBucketCounts(IReadOnlyList<long> bucketCounts)
         {
             // The first bucket (underflow bucket) should always be 0 count because the Metrics first bucket
             // is [0, first_bound) but Stackdriver distribution consists of an underflow bucket (number 0).
@@ -216,14 +216,14 @@ namespace OpenCensus.Exporter.Stackdriver.Implementation
         /// <returns></returns>
         public static Metric GetMetric(
             IView view,
-            IList<ITagValue> tagValues,
+            IReadOnlyList<ITagValue> tagValues,
             MetricDescriptor metricDescriptor,
             string domain)
         {
             var metric = new Metric();
             metric.Type = metricDescriptor.Type;
 
-            IList<ITagKey> columns = view.Columns;
+            IReadOnlyList<ITagKey> columns = view.Columns;
 
             // Populate metric labels
             for (int i = 0; i < tagValues.Count; i++)
@@ -271,7 +271,7 @@ namespace OpenCensus.Exporter.Stackdriver.Implementation
             foreach (var entry in viewData.AggregationMap)
             {
                 var timeSeries = new TimeSeries();
-                IList<ITagValue> labels = entry.Key.Values;
+                IReadOnlyList<ITagValue> labels = entry.Key.Values;
                 IAggregationData points = entry.Value;
                 
                 timeSeries.Resource = monitoredResource;

--- a/src/OpenCensus.Exporter.Zipkin/Implementation/TraceExporterHandler.cs
+++ b/src/OpenCensus.Exporter.Zipkin/Implementation/TraceExporterHandler.cs
@@ -163,7 +163,7 @@ namespace OpenCensus.Exporter.Zipkin.Implementation
             return ZipkinSpanKind.CLIENT;
         }
 
-        private async Task SendSpansAsync(List<ZipkinSpan> spans)
+        private async Task SendSpansAsync(IEnumerable<ZipkinSpan> spans)
         {
             try
             {
@@ -206,7 +206,7 @@ namespace OpenCensus.Exporter.Zipkin.Implementation
             return request;
         }
 
-        private HttpContent GetRequestContent(IList<ZipkinSpan> toSerialize)
+        private HttpContent GetRequestContent(IEnumerable<ZipkinSpan> toSerialize)
         {
             try
             {

--- a/src/OpenCensus/Stats/Aggregations/DistributionData.cs
+++ b/src/OpenCensus/Stats/Aggregations/DistributionData.cs
@@ -23,7 +23,7 @@ namespace OpenCensus.Stats.Aggregations
 
     public class DistributionData : AggregationData, IDistributionData
     {
-        internal DistributionData(double mean, long count, double min, double max, double sumOfSquaredDeviations, IList<long> bucketCounts)
+        internal DistributionData(double mean, long count, double min, double max, double sumOfSquaredDeviations, IReadOnlyList<long> bucketCounts)
         {
             this.Mean = mean;
             this.Count = count;
@@ -43,9 +43,9 @@ namespace OpenCensus.Stats.Aggregations
 
         public double SumOfSquaredDeviations { get; }
 
-        public IList<long> BucketCounts { get; }
+        public IReadOnlyList<long> BucketCounts { get; }
 
-        public static IDistributionData Create(double mean, long count, double min, double max, double sumOfSquaredDeviations, IList<long> bucketCounts)
+        public static IDistributionData Create(double mean, long count, double min, double max, double sumOfSquaredDeviations, IReadOnlyList<long> bucketCounts)
         {
             if (!double.IsPositiveInfinity(min) || !double.IsNegativeInfinity(max))
             {
@@ -60,7 +60,7 @@ namespace OpenCensus.Stats.Aggregations
                 throw new ArgumentNullException(nameof(bucketCounts));
             }
 
-            IList<long> bucketCountsCopy = new List<long>(bucketCounts).AsReadOnly();
+            IReadOnlyList<long> bucketCountsCopy = new List<long>(bucketCounts).AsReadOnly();
 
             return new DistributionData(
                 mean, count, min, max, sumOfSquaredDeviations, bucketCountsCopy);

--- a/src/OpenCensus/Stats/BucketBoundaries.cs
+++ b/src/OpenCensus/Stats/BucketBoundaries.cs
@@ -23,14 +23,14 @@ namespace OpenCensus.Stats
 
     public sealed class BucketBoundaries : IBucketBoundaries
     {
-        private BucketBoundaries(IList<double> boundaries)
+        private BucketBoundaries(IReadOnlyList<double> boundaries)
         {
             this.Boundaries = boundaries;
         }
 
-        public IList<double> Boundaries { get; }
+        public IReadOnlyList<double> Boundaries { get; }
 
-        public static IBucketBoundaries Create(IList<double> bucketBoundaries)
+        public static IBucketBoundaries Create(IEnumerable<double> bucketBoundaries)
         {
             if (bucketBoundaries == null)
             {

--- a/src/OpenCensus/Stats/MeasureToViewMap.cs
+++ b/src/OpenCensus/Stats/MeasureToViewMap.cs
@@ -24,7 +24,7 @@ namespace OpenCensus.Stats
     internal sealed class MeasureToViewMap
     {
         private readonly object lck = new object();
-        private readonly IDictionary<string, IList<MutableViewData>> mutableMap = new Dictionary<string, IList<MutableViewData>>();
+        private readonly IDictionary<string, ICollection<MutableViewData>> mutableMap = new Dictionary<string, ICollection<MutableViewData>>();
 
         private readonly IDictionary<IViewName, IView> registeredViews = new Dictionary<IViewName, IView>();
 
@@ -197,7 +197,7 @@ namespace OpenCensus.Stats
                     return null;
                 }
 
-                this.mutableMap.TryGetValue(view.Measure.Name, out IList<MutableViewData> views);
+                this.mutableMap.TryGetValue(view.Measure.Name, out ICollection<MutableViewData> views);
                 if (views != null)
                 {
                     foreach (MutableViewData viewData in views)

--- a/src/OpenCensus/Stats/MutableViewData.cs
+++ b/src/OpenCensus/Stats/MutableViewData.cs
@@ -89,9 +89,9 @@ namespace OpenCensus.Stats
             }
         }
 
-        internal static IList<ITagValue> GetTagValues(IDictionary<ITagKey, ITagValue> tags, IList<ITagKey> columns)
+        internal static IReadOnlyList<ITagValue> GetTagValues(IDictionary<ITagKey, ITagValue> tags, IReadOnlyList<ITagKey> columns)
         {
-            IList<ITagValue> tagValues = new List<ITagValue>(columns.Count);
+            List<ITagValue> tagValues = new List<ITagValue>(columns.Count);
 
             // Record all the measures in a "Greedy" way.
             // Every view aggregates every measure. This is similar to doing a GROUPBY view’s keys.
@@ -109,7 +109,7 @@ namespace OpenCensus.Stats
                 }
             }
 
-            return tagValues;
+            return tagValues.AsReadOnly();
         }
 
         // Returns the milliseconds representation of a Duration.

--- a/src/OpenCensus/Stats/StatsExtensions.cs
+++ b/src/OpenCensus/Stats/StatsExtensions.cs
@@ -23,7 +23,7 @@ namespace OpenCensus.Stats
 
     public static class StatsExtensions
     {
-        public static bool ContainsKeys(this IView view, List<ITagKey> keys)
+        public static bool ContainsKeys(this IView view, IEnumerable<ITagKey> keys)
         {
             var columns = view.Columns;
             foreach (var key in keys)
@@ -37,12 +37,12 @@ namespace OpenCensus.Stats
             return true;
         }
 
-        public static IAggregationData SumWithTags(this IViewData viewData, IList<ITagValue> values = null)
+        public static IAggregationData SumWithTags(this IViewData viewData, IEnumerable<ITagValue> values = null)
         {
             return viewData.AggregationMap.WithTags(values).Sum(viewData.View);
         }
 
-        public static IDictionary<TagValues, IAggregationData> WithTags(this IDictionary<TagValues, IAggregationData> aggMap, IList<ITagValue> values)
+        public static IDictionary<TagValues, IAggregationData> WithTags(this IDictionary<TagValues, IAggregationData> aggMap, IEnumerable<ITagValue> values)
         {
             Dictionary<TagValues, IAggregationData> results = new Dictionary<TagValues, IAggregationData>();
 
@@ -183,7 +183,7 @@ namespace OpenCensus.Stats
                             dist.Max = arg.Max;
                         }
 
-                        IList<long> bucketCounts = arg.BucketCounts;
+                        IReadOnlyList<long> bucketCounts = arg.BucketCounts;
                         for (int i = 0; i < bucketCounts.Count; i++)
                         {
                             dist.BucketCounts[i] += bucketCounts[i];

--- a/src/OpenCensus/Stats/View.cs
+++ b/src/OpenCensus/Stats/View.cs
@@ -23,7 +23,7 @@ namespace OpenCensus.Stats
 
     public sealed class View : IView
     {
-        internal View(IViewName name, string description, IMeasure measure, IAggregation aggregation, IList<ITagKey> columns)
+        internal View(IViewName name, string description, IMeasure measure, IAggregation aggregation, IReadOnlyList<ITagKey> columns)
         {
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.Description = description ?? throw new ArgumentNullException(nameof(description));
@@ -40,9 +40,9 @@ namespace OpenCensus.Stats
 
         public IAggregation Aggregation { get; }
 
-        public IList<ITagKey> Columns { get; }
+        public IReadOnlyList<ITagKey> Columns { get; }
 
-        public static IView Create(IViewName name, string description, IMeasure measure, IAggregation aggregation, IList<ITagKey> columns)
+        public static IView Create(IViewName name, string description, IMeasure measure, IAggregation aggregation, IReadOnlyList<ITagKey> columns)
         {
             var set = new HashSet<ITagKey>(columns);
             if (set.Count != columns.Count)

--- a/src/OpenCensus/Tags/TagContextBase.cs
+++ b/src/OpenCensus/Tags/TagContextBase.cs
@@ -24,13 +24,13 @@ namespace OpenCensus.Tags
     public abstract class TagContextBase : ITagContext
     {
         /// <inheritdoc/>
-public override string ToString()
+        public override string ToString()
         {
             return "TagContext";
         }
 
-    /// <inheritdoc/>
-public override bool Equals(object other)
+        /// <inheritdoc/>
+        public override bool Equals(object other)
         {
             if (!(other is TagContextBase))
             {
@@ -66,8 +66,8 @@ public override bool Equals(object other)
             return Collections.AreEquivalent(tags1, tags2);
         }
 
-    /// <inheritdoc/>
-public override int GetHashCode()
+        /// <inheritdoc/>
+        public override int GetHashCode()
         {
             int hashCode = 0;
             foreach (var t in this)
@@ -78,9 +78,9 @@ public override int GetHashCode()
             return hashCode;
         }
 
-public abstract IEnumerator<ITag> GetEnumerator();
+        public abstract IEnumerator<ITag> GetEnumerator();
 
-IEnumerator IEnumerable.GetEnumerator()
+        IEnumerator IEnumerable.GetEnumerator()
         {
             return this.GetEnumerator();
         }

--- a/src/OpenCensus/Trace/Export/InProcessRunningSpanStore.cs
+++ b/src/OpenCensus/Trace/Export/InProcessRunningSpanStore.cs
@@ -32,7 +32,7 @@ namespace OpenCensus.Trace.Export
         {
             get
             {
-                ICollection<SpanBase> allRunningSpans = this.runningSpans.Copy();
+                IEnumerable<SpanBase> allRunningSpans = this.runningSpans.Copy();
                 Dictionary<string, int> numSpansPerName = new Dictionary<string, int>();
                 foreach (var span in allRunningSpans)
                 {
@@ -55,7 +55,7 @@ namespace OpenCensus.Trace.Export
 
         public override IEnumerable<ISpanData> GetRunningSpans(IRunningSpanStoreFilter filter)
         {
-            ICollection<SpanBase> allRunningSpans = this.runningSpans.Copy();
+            IReadOnlyCollection<SpanBase> allRunningSpans = this.runningSpans.Copy();
             int maxSpansToReturn = filter.MaxSpansToReturn == 0 ? allRunningSpans.Count : filter.MaxSpansToReturn;
             List<ISpanData> ret = new List<ISpanData>(maxSpansToReturn);
             foreach (var span in allRunningSpans)

--- a/src/OpenCensus/Trace/Export/LatencyBucketBoundaries.cs
+++ b/src/OpenCensus/Trace/Export/LatencyBucketBoundaries.cs
@@ -31,7 +31,7 @@ namespace OpenCensus.Trace.Export
         public static readonly ISampledLatencyBucketBoundaries Secondx10Secondx100 = new LatencyBucketBoundaries(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(100));
         public static readonly ISampledLatencyBucketBoundaries Secondx100Max = new LatencyBucketBoundaries(TimeSpan.FromSeconds(100), TimeSpan.MaxValue);
 
-        public static IList<ISampledLatencyBucketBoundaries> Values = new List<ISampledLatencyBucketBoundaries>()
+        public static IReadOnlyList<ISampledLatencyBucketBoundaries> Values = new List<ISampledLatencyBucketBoundaries>
         {
             ZeroMicrosx10, Microsx10Microsx100, Microsx100Millix1, Millix1Millix10, Millix10Millix100, Millix100Secondx1, Secondx1Secondx10, Secondx10Secondx100, Secondx100Max,
         };

--- a/src/OpenCensus/Trace/Export/NoopSampledSpanStore.cs
+++ b/src/OpenCensus/Trace/Export/NoopSampledSpanStore.cs
@@ -69,7 +69,7 @@ namespace OpenCensus.Trace.Export
             return EmptySpanData;
         }
 
-        public override void RegisterSpanNamesForCollection(IList<string> spanNames)
+        public override void RegisterSpanNamesForCollection(IEnumerable<string> spanNames)
         {
             if (spanNames == null)
             {
@@ -85,7 +85,7 @@ namespace OpenCensus.Trace.Export
             }
         }
 
-        public override void UnregisterSpanNamesForCollection(IList<string> spanNames)
+        public override void UnregisterSpanNamesForCollection(IEnumerable<string> spanNames)
         {
             if (spanNames == null)
             {

--- a/src/OpenCensus/Trace/Export/SampledSpanStoreBase.cs
+++ b/src/OpenCensus/Trace/Export/SampledSpanStoreBase.cs
@@ -52,8 +52,8 @@ namespace OpenCensus.Trace.Export
 
         public abstract IEnumerable<ISpanData> GetLatencySampledSpans(ISampledSpanStoreLatencyFilter filter);
 
-        public abstract void RegisterSpanNamesForCollection(IList<string> spanNames);
+        public abstract void RegisterSpanNamesForCollection(IEnumerable<string> spanNames);
 
-        public abstract void UnregisterSpanNamesForCollection(IList<string> spanNames);
+        public abstract void UnregisterSpanNamesForCollection(IEnumerable<string> spanNames);
     }
 }

--- a/src/OpenCensus/Trace/Export/SpanExporterWorker.cs
+++ b/src/OpenCensus/Trace/Export/SpanExporterWorker.cs
@@ -125,7 +125,7 @@ namespace OpenCensus.Trace.Export
             return spanImpl.ToSpanData();
         }
 
-        private void BuildList(ISpan item, List<ISpanData> toExport)
+        private void BuildList(ISpan item, ICollection<ISpanData> toExport)
         {
             if (item is Span span)
             {

--- a/src/OpenCensus/Trace/Span.cs
+++ b/src/OpenCensus/Trace/Span.cs
@@ -414,7 +414,7 @@ namespace OpenCensus.Trace
 
             ITimedEvents<IAnnotation> annotationsSpanData = CreateTimedEvents(this.InitializedAnnotations, this.timestampConverter);
             ITimedEvents<IMessageEvent> messageEventsSpanData = CreateTimedEvents(this.InitializedMessageEvents, this.timestampConverter);
-            LinkList linksSpanData = this.links == null ? LinkList.Create(new List<ILink>(), 0) : LinkList.Create(this.links.Events.ToList(), this.links.NumberOfDroppedEvents);
+            LinkList linksSpanData = this.links == null ? LinkList.Create(new List<ILink>(), 0) : LinkList.Create(this.links.Events, this.links.NumberOfDroppedEvents);
 
             return SpanData.Create(
                 this.Context,

--- a/src/OpenCensus/Trace/SpanBuilder.cs
+++ b/src/OpenCensus/Trace/SpanBuilder.cs
@@ -42,7 +42,7 @@ namespace OpenCensus.Trace
 
         private ISampler Sampler { get; set; }
 
-        private IEnumerable<ISpan> ParentLinks { get; set; } = new List<ISpan>();
+        private IEnumerable<ISpan> ParentLinks { get; set; } = Enumerable.Empty<ISpan>();
 
         private bool RecordEvents { get; set; }
 

--- a/src/OpenCensus/Utils/ConcurrentIntrusiveList.cs
+++ b/src/OpenCensus/Utils/ConcurrentIntrusiveList.cs
@@ -98,7 +98,7 @@ namespace OpenCensus.Utils
             }
         }
 
-        public IList<T> Copy()
+        public IReadOnlyList<T> Copy()
         {
             lock (this.lck)
             {

--- a/test/OpenCensus.Tests/Impl/Stats/MutableViewDataTest.cs
+++ b/test/OpenCensus.Tests/Impl/Stats/MutableViewDataTest.cs
@@ -47,7 +47,7 @@ namespace OpenCensus.Stats.Test
         [Fact]
         public void TestGetTagValues()
         {
-            List<ITagKey> columns = new List<ITagKey>() { CALLER, METHOD, ORIGINATOR };
+            IReadOnlyList<ITagKey> columns = new List<ITagKey>() { CALLER, METHOD, ORIGINATOR };
             IDictionary<ITagKey, ITagValue> tags = new Dictionary<ITagKey, ITagValue>() { { CALLER, CALLER_V }, { METHOD, METHOD_V } };
 
             Assert.Equal(new List<ITagValue>() { CALLER_V, METHOD_V, MutableViewData.UnknownTagValue },

--- a/test/OpenCensus.Tests/Impl/Stats/StatsRecorderTest.cs
+++ b/test/OpenCensus.Tests/Impl/Stats/StatsRecorderTest.cs
@@ -18,7 +18,6 @@ namespace OpenCensus.Stats.Test
 {
     using System;
     using System.Collections.Generic;
-    using OpenCensus.Common;
     using OpenCensus.Internal;
     using OpenCensus.Stats.Aggregations;
     using OpenCensus.Stats.Measures;
@@ -63,8 +62,7 @@ namespace OpenCensus.Stats.Test
 
             // record() should have used the default TagContext, so the tag value should be null.
             ICollection<TagValues> expected = new List<TagValues>() { TagValues.Create(new List<ITagValue>() { null }) };
-            Assert.Equal(expected, viewData.AggregationMap.Keys);
-          
+            Assert.Equal(expected, viewData.AggregationMap.Keys); 
         }
 
         [Fact]
@@ -147,7 +145,8 @@ namespace OpenCensus.Stats.Test
 
             StatsTestUtil.AssertAggregationMapEquals(
                 viewData.AggregationMap,
-                new Dictionary<TagValues, IAggregationData>() {
+                new Dictionary<TagValues, IAggregationData>()
+                {
                     { tv, StatsTestUtil.CreateAggregationData(Sum.Create(), MEASURE_DOUBLE, 1.0) },
                     { tv2, StatsTestUtil.CreateAggregationData(Sum.Create(), MEASURE_DOUBLE, 1.0) },
                 },
@@ -219,12 +218,11 @@ namespace OpenCensus.Stats.Test
                 view,
                 new Dictionary<TagValues, IAggregationData>(),
                 DateTimeOffset.MinValue, DateTimeOffset.MinValue);
-
         }
 
         class SimpleTagContext : TagContextBase
         {
-            private readonly IList<ITag> tags;
+            private readonly IEnumerable<ITag> tags;
 
             public SimpleTagContext(params ITag[] tags)
             {
@@ -235,7 +233,6 @@ namespace OpenCensus.Stats.Test
             {
                 return tags.GetEnumerator();
             }
-
         }
     }
 }

--- a/test/OpenCensus.Tests/Impl/Stats/ViewDataTest.cs
+++ b/test/OpenCensus.Tests/Impl/Stats/ViewDataTest.cs
@@ -18,7 +18,6 @@ namespace OpenCensus.Stats.Test
 {
     using System;
     using System.Collections.Generic;
-    using OpenCensus.Common;
     using OpenCensus.Stats.Aggregations;
     using OpenCensus.Stats.Measures;
     using OpenCensus.Tags;
@@ -29,7 +28,7 @@ namespace OpenCensus.Stats.Test
         // tag keys
         private static readonly ITagKey K1 = TagKey.Create("k1");
         private static readonly ITagKey K2 = TagKey.Create("k2");
-        private static readonly IList<ITagKey> TAG_KEYS = new List<ITagKey>() { K1, K2 };
+        private static readonly IReadOnlyList<ITagKey> TAG_KEYS = new List<ITagKey>() { K1, K2 };
 
         // tag values
         private static readonly ITagValue V1 = TagValue.Create("v1");

--- a/test/OpenCensus.Tests/Impl/Stats/ViewManagerTest.cs
+++ b/test/OpenCensus.Tests/Impl/Stats/ViewManagerTest.cs
@@ -18,6 +18,7 @@ namespace OpenCensus.Stats.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using OpenCensus.Common;
     using OpenCensus.Internal;
     using OpenCensus.Stats.Aggregations;
@@ -583,7 +584,7 @@ namespace OpenCensus.Stats.Test
         public void TestGetCumulativeViewDataWithEmptyBucketBoundaries()
         {
             IAggregation noHistogram =
-                Distribution.Create(BucketBoundaries.Create(new List<double>()));
+                Distribution.Create(BucketBoundaries.Create(Enumerable.Empty<double>()));
             IView view = CreateCumulativeView(VIEW_NAME, MEASURE_DOUBLE, noHistogram, new List<ITagKey>() { KEY });
             viewManager.RegisterView(view);
             statsRecorder

--- a/test/OpenCensus.Tests/Impl/Tags/TagContextBaseTest.cs
+++ b/test/OpenCensus.Tests/Impl/Tags/TagContextBaseTest.cs
@@ -27,26 +27,24 @@ namespace OpenCensus.Tags.Test
         [Fact]
         public void Equals_IgnoresTagOrderAndTagContextClass()
         {
-  
             var ctx1 = new SimpleTagContext(TAG1, TAG2);
             var ctx2 = new SimpleTagContext(TAG1, TAG2);
             var ctx3 = new SimpleTagContext(TAG2, TAG1);
             var ctx4 = new TestTagContext();
+
             Assert.True(ctx1.Equals(ctx2));
             Assert.True(ctx1.Equals(ctx3));
             Assert.True(ctx1.Equals(ctx4));
             Assert.True(ctx2.Equals(ctx3));
             Assert.True(ctx2.Equals(ctx4));
             Assert.True(ctx3.Equals(ctx4));
-
         }
 
         [Fact]
         public void Equals_HandlesNullIterator()
         {
-
-            var ctx1 = new SimpleTagContext((IList<ITag>)null);
-            var ctx2 = new SimpleTagContext((IList<ITag>)null);
+            var ctx1 = new SimpleTagContext((IEnumerable<ITag>)null);
+            var ctx2 = new SimpleTagContext((IEnumerable<ITag>)null);
             var ctx3 = new SimpleTagContext();
             Assert.True(ctx1.Equals(ctx2));
             Assert.True(ctx1.Equals(ctx3));
@@ -56,30 +54,27 @@ namespace OpenCensus.Tags.Test
         [Fact]
         public void Equals_DoesNotIgnoreNullTags()
         {
-
             var ctx1 = new SimpleTagContext(TAG1);
             var ctx2 = new SimpleTagContext(TAG1, null);
             var ctx3 = new SimpleTagContext(null, TAG1);
             var ctx4 = new SimpleTagContext(TAG1, null, null);
+
             Assert.True(ctx2.Equals(ctx3));
             Assert.False(ctx1.Equals(ctx2));
             Assert.False(ctx1.Equals(ctx3));
             Assert.False(ctx1.Equals(ctx4));
             Assert.False(ctx2.Equals(ctx4));
             Assert.False(ctx3.Equals(ctx4));
-
         }
 
         [Fact]
         public void Equals_DoesNotIgnoreDuplicateTags()
         {
-
             var ctx1 = new SimpleTagContext(TAG1);
             var ctx2 = new SimpleTagContext(TAG1, TAG1);
             Assert.True(ctx1.Equals(ctx1));
             Assert.True(ctx2.Equals(ctx2));
             Assert.False(ctx1.Equals(ctx2));
-
         }
 
         [Fact]
@@ -100,7 +95,7 @@ namespace OpenCensus.Tags.Test
 
         class SimpleTagContext : TagContextBase
         {
-            private readonly IList<ITag> tags;
+            private readonly IEnumerable<ITag> tags;
 
             // This Error Prone warning doesn't seem correct, because the constructor is just calling
             // another constructor.
@@ -109,17 +104,15 @@ namespace OpenCensus.Tags.Test
             {
             }
 
-            public SimpleTagContext(IList<ITag> tags)
+            public SimpleTagContext(IEnumerable<ITag> tags)
             {
-                this.tags = tags == null ? null : new List<ITag>(tags).AsReadOnly();
+                this.tags = tags == null ? null : new List<ITag>(tags);
             }
 
             public override IEnumerator<ITag> GetEnumerator()
             {
                 return tags == null ? null : tags.GetEnumerator();
             }
-
-
         }
     }
 }

--- a/test/OpenCensus.Tests/Impl/Trace/Export/SpanExporterTest.cs
+++ b/test/OpenCensus.Tests/Impl/Trace/Export/SpanExporterTest.cs
@@ -130,7 +130,7 @@ namespace OpenCensus.Trace.Export.Test
         public void ServiceHandlerThrowsException()
         {
             var mockHandler = Mock.Get<IHandler>(mockServiceHandler);
-            mockHandler.Setup((h) => h.ExportAsync(It.IsAny<IList<ISpanData>>())).Throws(new ArgumentException("No export for you."));
+            mockHandler.Setup((h) => h.ExportAsync(It.IsAny<IEnumerable<ISpanData>>())).Throws(new ArgumentException("No export for you."));
             // doThrow(new IllegalArgumentException("No export for you."))
             //    .when(mockServiceHandler)
             //    .export(anyListOf(SpanData));


### PR DESCRIPTION
Summary:
* Removed usage of _IList<T>/List<T>_ in public methods.
* Switch to usage of read-only collection where possible
* Switch to usage of Enumerable.Empty<T> to avoid unnecessary allocation where applicable
