### PR TITLE
Fix for loading GOOGLE_APPLICATION_CREDENTIALS json key file from read-only volumes

### DIFF
--- a/src/OpenCensus.Exporter.Stackdriver/Implementation/GoogleCloudResourceUtils.cs
+++ b/src/OpenCensus.Exporter.Stackdriver/Implementation/GoogleCloudResourceUtils.cs
@@ -47,7 +47,7 @@ namespace OpenCensus.Exporter.Stackdriver.Implementation
             string serviceAccountFilePath = Environment.GetEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS");
             if (!string.IsNullOrEmpty(serviceAccountFilePath) && File.Exists(serviceAccountFilePath))
             {
-                using (var stream = new FileStream(serviceAccountFilePath, FileMode.Open))
+                using (var stream = new FileStream(serviceAccountFilePath, FileMode.Open, FileAccess.Read))
                 {
                     var credential = Google.Apis.Auth.OAuth2.ServiceAccountCredential.FromServiceAccountData(stream);
                     return credential.ProjectId;


### PR DESCRIPTION
This pull request fixes an issue where the GOOGLE_APPLICATION_CREDENTIALS json key file might be on a read-only volume, which can make it throw System.IO.IOException. Setting the FileAccess.Read fixes this.