### PR TITLE
Fixed README typo OpenTelemetry -> OpenCensus?

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SDK](https://github.com/open-telemetry/opentelemetry-dotnet/).
 [![OpenTelemetryLogo](https://opentelemetry.io/img/logos/opentelemetry-horizontal-color.png)](https://github.com/open-telemetry/opentelemetry-dotnet/)
 
 All the open issues and PRs on this repository will be moved to the new project
-or closed. We do not expect any new versions of OpenTelemetry .NET SDK shipped.
+or closed. We do not expect any new versions of OpenCensus .NET SDK shipped.
 
 OpenCensus C# has never left the Alpha release stage. Please see this [project
 description](PROJECT_DESCRIPTION.md) for details of what was built. If you took


### PR DESCRIPTION
It does not make sense to me that there will be no more versions of OpenTelemetry, so I think this is a typo :)